### PR TITLE
Fix SVG clearing, deck breadcrumbs, and GitHub footer link

### DIFF
--- a/fasolt.client/src/components/CardTable.vue
+++ b/fasolt.client/src/components/CardTable.vue
@@ -25,10 +25,12 @@ const props = withDefaults(defineProps<{
   showDecks?: boolean
   showPagination?: boolean
   pageSize?: number
+  deckContext?: { id: string; name: string } | null
 }>(), {
   showDecks: false,
   showPagination: false,
   pageSize: 20,
+  deckContext: null,
 })
 
 const emit = defineEmits<{
@@ -48,10 +50,13 @@ const columns = computed<ColumnDef<any>[]>(() => {
         const display = val.length > 80 ? val.slice(0, 80) + '…' : val
         const source = row.original.sourceFile
         const hasSvg = row.original.frontSvg || row.original.backSvg
+        const cardLink = props.deckContext
+          ? `/cards/${row.original.id}?deckId=${props.deckContext.id}&deckName=${encodeURIComponent(props.deckContext.name)}`
+          : `/cards/${row.original.id}`
         return h('div', { class: 'min-w-0' }, [
           h('div', { class: 'flex items-center gap-1.5' }, [
             h(RouterLink, {
-              to: `/cards/${row.original.id}`,
+              to: cardLink,
               class: 'hover:text-accent transition-colors',
             }, () => display),
             hasSvg ? h(Image, { class: 'size-3 text-muted-foreground shrink-0' }) : null,
@@ -104,7 +109,12 @@ const columns = computed<ColumnDef<any>[]>(() => {
     cell: ({ row }) => {
       const card = row.original
       const buttons = [
-        h(Button, { variant: 'ghost', size: 'sm', class: 'h-6 text-[10px]', onClick: () => router.push(`/cards/${card.id}?edit=true`) }, () => 'Edit'),
+        h(Button, { variant: 'ghost', size: 'sm', class: 'h-6 text-[10px]', onClick: () => {
+          const editLink = props.deckContext
+            ? `/cards/${card.id}?edit=true&deckId=${props.deckContext.id}&deckName=${encodeURIComponent(props.deckContext.name)}`
+            : `/cards/${card.id}?edit=true`
+          router.push(editLink)
+        } }, () => 'Edit'),
       ]
       if (!props.showDecks) {
         buttons.push(

--- a/fasolt.client/src/layouts/AppLayout.vue
+++ b/fasolt.client/src/layouts/AppLayout.vue
@@ -64,7 +64,12 @@ const activeTab = computed(() => {
     </main>
     <footer class="hidden border-t border-border/40 px-5 py-2 text-[10px] text-muted-foreground/50 sm:flex sm:items-center sm:justify-between">
       <span>fasolt v{{ version }}</span>
-      <RouterLink to="/privacy" class="hover:text-muted-foreground">Privacy Policy</RouterLink>
+      <div class="flex items-center gap-3">
+        <a href="https://github.com/philphilphil/fasolt" target="_blank" rel="noopener noreferrer" class="hover:text-muted-foreground transition-colors" aria-label="GitHub">
+          <svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+        </a>
+        <RouterLink to="/privacy" class="hover:text-muted-foreground">Privacy Policy</RouterLink>
+      </div>
     </footer>
     <BottomNav />
   </div>

--- a/fasolt.client/src/views/CardDetailView.vue
+++ b/fasolt.client/src/views/CardDetailView.vue
@@ -40,6 +40,12 @@ const resetOpen = ref(false)
 const resetting = ref(false)
 const resetSuccess = ref(false)
 
+const deckContext = computed(() => {
+  const id = route.query.deckId as string | undefined
+  const name = route.query.deckName as string | undefined
+  return id && name ? { id, name } : null
+})
+
 const truncatedFront = computed(() => {
   if (!card.value) return ''
   const plain = stripMarkdown(card.value.front)
@@ -84,8 +90,8 @@ async function save() {
     card.value = await cardsStore.updateCard(card.value.id, {
       front: front.value,
       back: back.value,
-      frontSvg: editFrontSvg.value || null,
-      backSvg: editBackSvg.value || null,
+      frontSvg: editFrontSvg.value,
+      backSvg: editBackSvg.value,
       sourceFile: editSourceFile.value || null,
       sourceHeading: editSourceHeading.value || null,
       deckIds: editDeckIds.value,
@@ -115,7 +121,7 @@ async function confirmReset() {
 }
 
 function onDeleted() {
-  router.replace('/cards')
+  router.replace(deckContext.value ? `/decks/${deckContext.value.id}` : '/cards')
 }
 </script>
 
@@ -125,7 +131,14 @@ function onDeleted() {
   <div v-else-if="card" class="space-y-6">
     <!-- Breadcrumb -->
     <div class="text-[11px] text-muted-foreground">
-      <RouterLink to="/cards" class="hover:text-foreground transition-colors">Cards</RouterLink>
+      <template v-if="deckContext">
+        <RouterLink to="/decks" class="hover:text-foreground transition-colors">Decks</RouterLink>
+        <span class="mx-1.5">/</span>
+        <RouterLink :to="`/decks/${deckContext.id}`" class="hover:text-foreground transition-colors">{{ deckContext.name }}</RouterLink>
+      </template>
+      <template v-else>
+        <RouterLink to="/cards" class="hover:text-foreground transition-colors">Cards</RouterLink>
+      </template>
       <span class="mx-1.5">/</span>
       <span class="text-foreground">{{ truncatedFront }}</span>
     </div>

--- a/fasolt.client/src/views/DeckDetailView.vue
+++ b/fasolt.client/src/views/DeckDetailView.vue
@@ -170,6 +170,7 @@ const stateCounts = computed(() => {
       <CardTable
         v-if="deck.cards.length > 0"
         :cards="deck.cards"
+        :deck-context="{ id: deck.id, name: deck.name }"
         @delete="(card) => { deleteCardTarget = card; deleteCardOpen = true }"
         @remove="(card) => removeCard(card.id)"
       >


### PR DESCRIPTION
## Summary
- **Fix SVG removal** (#61): Clearing an SVG from a card and saving now works. The frontend was converting empty string to `null`, but the backend treats `null` as "don't update" — empty string is what triggers a clear.
- **Deck breadcrumbs** (#61): When navigating to a card from a deck detail view, breadcrumbs now show `Decks / Deck Name / Card` instead of `Cards / Card`. Deleting a card in deck context navigates back to the deck.
- **GitHub footer link**: Added a small GitHub logo linking to the repo in the app footer.

## Test plan
- [x] Clear SVG from a card, save, verify SVG is removed and stays removed on re-edit
- [x] Navigate from deck detail to card, verify breadcrumb shows deck context
- [x] Navigate directly to card (no deck context), verify breadcrumb shows Cards
- [x] Verify GitHub icon appears in footer and links to repo
- [x] Type-check passes (`vue-tsc --noEmit`)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)