### PR TITLE
fix: settings two-column layout and iOS empty state

### DIFF
--- a/fasolt.client/src/stores/snapshots.ts
+++ b/fasolt.client/src/stores/snapshots.ts
@@ -11,6 +11,15 @@ export const useSnapshotsStore = defineStore('snapshots', () => {
     return apiFetch<{ created: number; skipped: number }>('/snapshots', { method: 'POST' })
   }
 
+  async function fetchRecent() {
+    loading.value = true
+    try {
+      snapshots.value = await apiFetch<DeckSnapshot[]>('/snapshots/recent')
+    } finally {
+      loading.value = false
+    }
+  }
+
   async function fetchByDeck(deckId: string) {
     loading.value = true
     try {
@@ -35,5 +44,5 @@ export const useSnapshotsStore = defineStore('snapshots', () => {
     await apiFetch(`/snapshots/${snapshotId}`, { method: 'DELETE' })
   }
 
-  return { snapshots, loading, createAll, fetchByDeck, getDiff, restore, deleteSnapshot }
+  return { snapshots, loading, createAll, fetchRecent, fetchByDeck, getDiff, restore, deleteSnapshot }
 })

--- a/fasolt.client/src/views/SettingsView.vue
+++ b/fasolt.client/src/views/SettingsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -24,6 +24,7 @@ async function createSnapshot() {
     snapshotCreated.value = result.created
     snapshotSkipped.value = result.skipped
     snapshotSuccess.value = true
+    snapshotsStore.fetchRecent()
   } catch {
     snapshotError.value = 'Failed to create snapshot. Please try again.'
   } finally {
@@ -84,9 +85,20 @@ const confirmNewPassword = ref('')
 const passwordSuccess = ref(false)
 const passwordError = ref('')
 
+const snapshotCount = computed(() => snapshotsStore.snapshots.length)
+const lastSnapshot = computed(() => {
+  if (snapshotsStore.snapshots.length === 0) return null
+  const date = new Date(snapshotsStore.snapshots[0].createdAt)
+  return date.toLocaleDateString(undefined, { dateStyle: 'medium' })
+})
+const totalCardsBacked = computed(() =>
+  snapshotsStore.snapshots.reduce((sum, s) => sum + s.cardCount, 0)
+)
+
 onMounted(() => {
   newEmail.value = auth.user?.email || ''
   loadSchedulingSettings()
+  snapshotsStore.fetchRecent()
 })
 
 async function saveEmail() {
@@ -132,130 +144,150 @@ async function savePassword() {
   <div class="flex flex-col gap-6">
     <h1 class="text-lg font-bold tracking-tight">Settings</h1>
 
-    <Card class="border-border/60">
-      <CardHeader>
-        <CardTitle class="text-sm">Snapshots</CardTitle>
-      </CardHeader>
-      <CardContent class="flex flex-col gap-3">
-        <p class="text-xs text-muted-foreground">
-          Create a backup of all your decks. Snapshots capture every card's content so you can restore it later if something goes wrong. The last 10 snapshots per deck are kept automatically. Study progress is not affected by restoring — only card content (front, back, images, source) is reverted.
-        </p>
-        <div v-if="snapshotSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-xs text-success">
-          <template v-if="snapshotCreated > 0 && snapshotSkipped === 0">
-            Snapshot created for {{ snapshotCreated }} deck{{ snapshotCreated !== 1 ? 's' : '' }}.
-          </template>
-          <template v-else-if="snapshotCreated > 0 && snapshotSkipped > 0">
-            Snapshot created for {{ snapshotCreated }} deck{{ snapshotCreated !== 1 ? 's' : '' }}. {{ snapshotSkipped }} unchanged, skipped.
-          </template>
-          <template v-else>
-            All decks unchanged — no snapshots needed.
-          </template>
-        </div>
-        <div v-if="snapshotError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ snapshotError }}</div>
-        <Button size="sm" class="self-start text-xs" :disabled="snapshotting" @click="createSnapshot">
-          {{ snapshotting ? 'Creating...' : 'Create snapshot' }}
-        </Button>
-      </CardContent>
-    </Card>
-
-    <Card class="border-border/60">
-      <CardHeader>
-        <CardTitle class="text-sm">Scheduling</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form class="flex flex-col gap-4" @submit.prevent="saveSchedulingSettings">
-          <div v-if="schedulingLoading" class="text-xs text-muted-foreground">Loading...</div>
-          <template v-else>
-            <div v-if="schedulingSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-xs text-success">Settings saved.</div>
-            <div v-if="schedulingError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ schedulingError }}</div>
-
-            <div class="flex flex-col gap-1.5">
-              <label for="desired-retention" class="text-xs font-medium">Desired retention</label>
-              <Input id="desired-retention" v-model.number="desiredRetention" type="number" min="0.70" max="0.97" step="0.01" required />
-              <p class="text-xs text-muted-foreground">
-                How likely you want to remember a card when it comes up for review. Higher values (e.g. 0.95) mean more frequent reviews but stronger recall. Lower values (e.g. 0.85) mean fewer reviews but more forgetting. Changes apply to future reviews only — cards already scheduled keep their current due dates.
-              </p>
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div class="flex flex-col gap-6">
+        <Card class="border-border/60">
+          <CardHeader>
+            <CardTitle class="text-sm">Snapshots</CardTitle>
+          </CardHeader>
+          <CardContent class="flex flex-col gap-3">
+            <p class="text-xs text-muted-foreground">
+              Create a backup of all your decks. Snapshots capture every card's content so you can restore it later if something goes wrong. The last 10 snapshots per deck are kept automatically. Study progress is not affected by restoring — only card content (front, back, images, source) is reverted.
+            </p>
+            <div v-if="snapshotSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-xs text-success">
+              <template v-if="snapshotCreated > 0 && snapshotSkipped === 0">
+                Snapshot created for {{ snapshotCreated }} deck{{ snapshotCreated !== 1 ? 's' : '' }}.
+              </template>
+              <template v-else-if="snapshotCreated > 0 && snapshotSkipped > 0">
+                Snapshot created for {{ snapshotCreated }} deck{{ snapshotCreated !== 1 ? 's' : '' }}. {{ snapshotSkipped }} unchanged, skipped.
+              </template>
+              <template v-else>
+                All decks unchanged — no snapshots needed.
+              </template>
             </div>
-
-            <div class="flex flex-col gap-1.5">
-              <label for="maximum-interval" class="text-xs font-medium">Maximum interval (days)</label>
-              <Input id="maximum-interval" v-model.number="maximumInterval" type="number" min="1" max="36500" step="1" required />
-              <p class="text-xs text-muted-foreground">
-                The longest gap allowed between reviews, in days. For example, 365 means you'll see every card at least once a year. The default (36500 days ≈ 100 years) means there's effectively no cap.
-              </p>
+            <div v-if="snapshotError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ snapshotError }}</div>
+            <div v-if="snapshotCount > 0" class="flex gap-6 text-xs">
+              <div class="flex flex-col">
+                <span class="text-muted-foreground">Snapshots</span>
+                <span class="font-medium">{{ snapshotCount }}</span>
+              </div>
+              <div class="flex flex-col">
+                <span class="text-muted-foreground">Cards backed up</span>
+                <span class="font-medium">{{ totalCardsBacked }}</span>
+              </div>
+              <div v-if="lastSnapshot" class="flex flex-col">
+                <span class="text-muted-foreground">Last snapshot</span>
+                <span class="font-medium">{{ lastSnapshot }}</span>
+              </div>
             </div>
+            <Button size="sm" class="self-start text-xs" :disabled="snapshotting" @click="createSnapshot">
+              {{ snapshotting ? 'Creating...' : 'Create snapshot' }}
+            </Button>
+          </CardContent>
+        </Card>
 
-            <Button type="submit" size="sm" class="self-start text-xs">Save scheduling settings</Button>
-          </template>
-        </form>
-      </CardContent>
-    </Card>
+        <Card class="border-border/60">
+          <CardHeader>
+            <CardTitle class="text-sm">Account</CardTitle>
+          </CardHeader>
+          <CardContent class="flex flex-col gap-1">
+            <div class="flex items-center gap-2 text-xs">
+              <span class="text-muted-foreground">Signed in as</span>
+              <span class="font-medium">{{ auth.user?.displayName || auth.user?.email }}</span>
+            </div>
+            <div class="flex items-center gap-2 text-xs">
+              <span class="text-muted-foreground">Account type</span>
+              <span v-if="auth.isExternalAccount" class="inline-flex items-center gap-1 font-medium">
+                <svg class="h-3.5 w-3.5" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                GitHub
+              </span>
+              <span v-else class="font-medium">Email &amp; password</span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
 
-    <Card v-if="!auth.isExternalAccount" class="border-border/60">
-      <CardHeader>
-        <CardTitle class="text-sm">Email address</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form class="flex flex-col gap-3" @submit.prevent="saveEmail">
-          <div v-if="emailSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-xs text-success">Email updated.</div>
-          <div v-if="emailError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ emailError }}</div>
-          <div class="flex flex-col gap-1.5">
-            <label for="new-email" class="text-xs font-medium">New email</label>
-            <Input id="new-email" v-model="newEmail" type="email" required />
-          </div>
-          <div class="flex flex-col gap-1.5">
-            <label for="email-password" class="text-xs font-medium">Current password</label>
-            <Input id="email-password" v-model="emailCurrentPassword" type="password" required autocomplete="off" />
-          </div>
-          <Button type="submit" size="sm" class="self-start text-xs">Update email</Button>
-        </form>
-      </CardContent>
-    </Card>
+      <Card class="border-border/60">
+        <CardHeader>
+          <CardTitle class="text-sm">Scheduling</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form class="flex flex-col gap-4" @submit.prevent="saveSchedulingSettings">
+            <div v-if="schedulingLoading" class="text-xs text-muted-foreground">Loading...</div>
+            <template v-else>
+              <div v-if="schedulingSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-xs text-success">Settings saved.</div>
+              <div v-if="schedulingError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ schedulingError }}</div>
 
-    <Card v-if="!auth.isExternalAccount" class="border-border/60">
-      <CardHeader>
-        <CardTitle class="text-sm">Change password</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form class="flex flex-col gap-3" @submit.prevent="savePassword">
-          <div v-if="passwordSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-xs text-success">Password changed.</div>
-          <div v-if="passwordError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ passwordError }}</div>
-          <div class="flex flex-col gap-1.5">
-            <label for="current-password" class="text-xs font-medium">Current password</label>
-            <Input id="current-password" v-model="currentPassword" type="password" required autocomplete="current-password" />
-          </div>
-          <div class="flex flex-col gap-1.5">
-            <label for="new-password" class="text-xs font-medium">New password</label>
-            <Input id="new-password" v-model="newPassword" type="password" required autocomplete="new-password" />
-          </div>
-          <div class="flex flex-col gap-1.5">
-            <label for="confirm-new-password" class="text-xs font-medium">Confirm new password</label>
-            <Input id="confirm-new-password" v-model="confirmNewPassword" type="password" required autocomplete="new-password" />
-          </div>
-          <Button type="submit" size="sm" class="self-start text-xs">Change password</Button>
-        </form>
-      </CardContent>
-    </Card>
+              <div class="flex flex-col gap-1.5">
+                <label for="desired-retention" class="text-xs font-medium">Desired retention</label>
+                <Input id="desired-retention" v-model.number="desiredRetention" type="number" min="0.70" max="0.97" step="0.01" required />
+                <p class="text-xs text-muted-foreground">
+                  How likely you want to remember a card when it comes up for review. Higher values (e.g. 0.95) mean more frequent reviews but stronger recall. Lower values (e.g. 0.85) mean fewer reviews but more forgetting. Changes apply to future reviews only — cards already scheduled keep their current due dates.
+                </p>
+              </div>
 
-    <Card class="border-border/60">
-      <CardHeader>
-        <CardTitle class="text-sm">Account</CardTitle>
-      </CardHeader>
-      <CardContent class="flex flex-col gap-1">
-        <div class="flex items-center gap-2 text-xs">
-          <span class="text-muted-foreground">Signed in as</span>
-          <span class="font-medium">{{ auth.user?.displayName || auth.user?.email }}</span>
-        </div>
-        <div class="flex items-center gap-2 text-xs">
-          <span class="text-muted-foreground">Account type</span>
-          <span v-if="auth.isExternalAccount" class="inline-flex items-center gap-1 font-medium">
-            <svg class="h-3.5 w-3.5" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-            GitHub
-          </span>
-          <span v-else class="font-medium">Email &amp; password</span>
-        </div>
-      </CardContent>
-    </Card>
+              <div class="flex flex-col gap-1.5">
+                <label for="maximum-interval" class="text-xs font-medium">Maximum interval (days)</label>
+                <Input id="maximum-interval" v-model.number="maximumInterval" type="number" min="1" max="36500" step="1" required />
+                <p class="text-xs text-muted-foreground">
+                  The longest gap allowed between reviews, in days. For example, 365 means you'll see every card at least once a year. The default (36500 days ≈ 100 years) means there's effectively no cap.
+                </p>
+              </div>
+
+              <Button type="submit" size="sm" class="self-start text-xs">Save scheduling settings</Button>
+            </template>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+
+    <div v-if="!auth.isExternalAccount" class="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
+      <Card class="border-border/60">
+        <CardHeader>
+          <CardTitle class="text-sm">Email address</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form class="flex flex-col gap-3" @submit.prevent="saveEmail">
+            <div v-if="emailSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-xs text-success">Email updated.</div>
+            <div v-if="emailError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ emailError }}</div>
+            <div class="flex flex-col gap-1.5">
+              <label for="new-email" class="text-xs font-medium">New email</label>
+              <Input id="new-email" v-model="newEmail" type="email" required />
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <label for="email-password" class="text-xs font-medium">Current password</label>
+              <Input id="email-password" v-model="emailCurrentPassword" type="password" required autocomplete="off" />
+            </div>
+            <Button type="submit" size="sm" class="self-start text-xs">Update email</Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card class="border-border/60">
+        <CardHeader>
+          <CardTitle class="text-sm">Change password</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form class="flex flex-col gap-3" @submit.prevent="savePassword">
+            <div v-if="passwordSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-xs text-success">Password changed.</div>
+            <div v-if="passwordError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ passwordError }}</div>
+            <div class="flex flex-col gap-1.5">
+              <label for="current-password" class="text-xs font-medium">Current password</label>
+              <Input id="current-password" v-model="currentPassword" type="password" required autocomplete="current-password" />
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <label for="new-password" class="text-xs font-medium">New password</label>
+              <Input id="new-password" v-model="newPassword" type="password" required autocomplete="new-password" />
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <label for="confirm-new-password" class="text-xs font-medium">Confirm new password</label>
+              <Input id="confirm-new-password" v-model="confirmNewPassword" type="password" required autocomplete="new-password" />
+            </div>
+            <Button type="submit" size="sm" class="self-start text-xs">Change password</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
 
   </div>
 </template>

--- a/fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift
+++ b/fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift
@@ -17,6 +17,15 @@ struct DashboardView: View {
                     if viewModel.totalCards > 0 {
                         stateBar
                     }
+                    if viewModel.totalCards == 0 && !viewModel.isLoading && viewModel.errorMessage == nil {
+                        ContentUnavailableView(
+                            "No cards yet",
+                            systemImage: "rectangle.on.rectangle",
+                            description: Text("Create cards via MCP (or the UI) to get started")
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 32)
+                    }
                     if !dueDecks.isEmpty {
                         deckSection
                     }
@@ -43,15 +52,6 @@ struct DashboardView: View {
                             Task { await viewModel.loadStats() }
                         }
                     }
-                }
-            }
-            .overlay {
-                if viewModel.totalCards == 0 && !viewModel.isLoading && viewModel.errorMessage == nil {
-                    ContentUnavailableView(
-                        "No cards yet",
-                        systemImage: "rectangle.on.rectangle",
-                        description: Text("Create cards via the API or MCP tools to get started")
-                    )
                 }
             }
             .task {


### PR DESCRIPTION
## Summary
- **#66**: Settings page now uses a two-column grid — Snapshots + Account stacked on the left, Scheduling on the right; Email + Password side by side below. Added snapshot stats (count, cards backed up, last snapshot date) to the Snapshots card.
- **#65**: iOS Dashboard empty state moved from overlay to inline content below the hero card and stats, so the dashboard remains visible. Updated copy to "Create cards via MCP (or the UI) to get started".

## Test plan
- [ ] Open Settings page on desktop — verify two-column layout with Snapshots+Account left, Scheduling right
- [ ] Resize browser to mobile — verify cards stack vertically
- [ ] Create a snapshot — verify stats update
- [ ] Check Settings page as a GitHub-linked account — verify Email/Password row is hidden
- [ ] iOS: open Dashboard with no cards — verify empty state shows below hero card, not as overlay

Closes #66
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)