### PR TITLE
feat: fuzzy search — match cards containing all query terms

### DIFF
--- a/fasolt.Server/Application/Services/SearchService.cs
+++ b/fasolt.Server/Application/Services/SearchService.cs
@@ -11,22 +11,27 @@ public class SearchService(AppDbContext db)
         if (string.IsNullOrWhiteSpace(query) || query.Trim().Length < 2)
             return new SearchResponse([], []);
 
-        var escaped = query.Trim()
-            .Replace("\\", "\\\\")
-            .Replace("%", "\\%")
-            .Replace("_", "\\_");
-        var pattern = $"%{escaped}%";
+        var terms = query.Trim()
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(t => "%" + t.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_") + "%")
+            .ToList();
 
-        var cards = await db.Cards
-            .Where(c => c.UserId == userId &&
-                (EF.Functions.ILike(c.Front, pattern, "\\") || EF.Functions.ILike(c.Back, pattern, "\\")))
+        var cardsQuery = db.Cards.Where(c => c.UserId == userId);
+        foreach (var term in terms)
+            cardsQuery = cardsQuery.Where(c =>
+                EF.Functions.ILike(c.Front, term, "\\") || EF.Functions.ILike(c.Back, term, "\\"));
+
+        var cards = await cardsQuery
             .OrderByDescending(c => c.CreatedAt)
             .Take(10)
             .Select(c => new CardSearchResult(c.PublicId, c.Front, c.State))
             .ToListAsync();
 
-        var decks = await db.Decks
-            .Where(d => d.UserId == userId && EF.Functions.ILike(d.Name, pattern, "\\"))
+        var decksQuery = db.Decks.Where(d => d.UserId == userId);
+        foreach (var term in terms)
+            decksQuery = decksQuery.Where(d => EF.Functions.ILike(d.Name, term, "\\"));
+
+        var decks = await decksQuery
             .OrderBy(d => d.Name)
             .Take(10)
             .Select(d => new DeckSearchResult(

--- a/fasolt.Tests/SearchServiceTests.cs
+++ b/fasolt.Tests/SearchServiceTests.cs
@@ -86,4 +86,37 @@ public class SearchServiceTests : IAsyncLifetime
         result.Cards.Should().ContainSingle(c => c.Headline.Contains("snake_case"));
     }
 
+    [Fact]
+    public async Task Search_MultiTermQuery_RequiresAllTerms()
+    {
+        await using var db = _db.CreateDbContext();
+        var cardSvc = new CardService(db);
+        var searchSvc = new SearchService(db);
+
+        await cardSvc.CreateCard(UserId, "Was ist der Unterschied von Apfel und der Birne", "Äpfel und Birnen sind Obstsorten.", null, null);
+        await cardSvc.CreateCard(UserId, "Was ist ein Apfel", "Ein Apfel ist eine Frucht.", null, null);
+        await cardSvc.CreateCard(UserId, "Unrelated card", "Nothing here.", null, null);
+
+        var result = await searchSvc.Search(UserId, "apfel birne");
+
+        result.Cards.Should().ContainSingle(c => c.Headline.Contains("Apfel"));
+        result.Cards[0].Headline.Should().Contain("Birne");
+    }
+
+    [Fact]
+    public async Task Search_MultiTermQuery_MatchesAcrossFrontAndBack()
+    {
+        await using var db = _db.CreateDbContext();
+        var cardSvc = new CardService(db);
+        var searchSvc = new SearchService(db);
+
+        await cardSvc.CreateCard(UserId, "Photosynthesis", "Plants convert sunlight into energy.", null, null);
+        await cardSvc.CreateCard(UserId, "Respiration", "Cells convert glucose into ATP.", null, null);
+
+        // "photosynthesis" is in front, "sunlight" is in back — both must match
+        var result = await searchSvc.Search(UserId, "photosynthesis sunlight");
+
+        result.Cards.Should().ContainSingle(c => c.Headline.Contains("Photosynthesis"));
+    }
+
 }


### PR DESCRIPTION
## Summary

Split multi-word queries into individual terms and require all terms to be present (AND logic), instead of exact phrase matching.

**Before:** Searching "apfel birne" would only find cards containing the exact phrase "apfel birne".
**After:** Searching "apfel birne" finds any card where both "apfel" and "birne" appear anywhere in the front or back text, in any order.

## Changes

- **`SearchService.cs`**: Split query on whitespace, escape each term individually, and chain `ILike` conditions so all terms must match
- **`SearchServiceTests.cs`**: Added two new tests — multi-term query requiring all terms, and multi-term match across front and back fields

## Test Plan

- [x] All 7 search tests pass (`dotnet test --filter Search`)
- [x] Single-word queries continue to work
- [x] Multi-word queries match all terms (AND logic)
- [x] Works for both API (`GET /api/search`) and MCP (`SearchCards`) — both call the same `SearchService`

Closes #79