### PR TITLE
feat: add SEO metadata and titles

### DIFF
--- a/fasolt.client/index.html
+++ b/fasolt.client/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/logo.svg" type="image/svg+xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="fasolt is MCP-first spaced repetition for markdown notes. Let your AI agent turn notes into flashcards, then study them with FSRS on the web or iOS."
+    />
+    <meta name="theme-color" content="#0b111a" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet" />

--- a/fasolt.client/public/llms.txt
+++ b/fasolt.client/public/llms.txt
@@ -1,0 +1,26 @@
+# fasolt
+
+fasolt is an MCP-first spaced repetition app for markdown notes.
+
+Users keep their notes locally. An AI agent reads those notes, creates flashcards in fasolt via MCP, and fasolt handles study and review with the FSRS spaced repetition algorithm. Cards can also be edited in the web app or the iOS app.
+
+Notable features:
+- MCP-based flashcard creation and management
+- SVG support for diagrams and visual explanations on cards
+- Source tracking with source file and heading provenance
+- Decks for organizing study material
+- Full-text search across cards
+- Dashboard with due counts and study stats
+- Web app and iOS app for editing and review
+- Self-hosting support with Docker
+
+Public URLs:
+- Home: https://fasolt.app/
+- Algorithm: https://fasolt.app/algorithm
+- Privacy: https://fasolt.app/privacy
+
+Integration URLs:
+- Remote MCP endpoint: https://fasolt.app/mcp
+- GitHub repository: https://github.com/philphilphil/fasolt
+
+For setup, self-hosting, and implementation details, see the GitHub repository README.

--- a/fasolt.client/public/robots.txt
+++ b/fasolt.client/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://fasolt.app/sitemap.xml

--- a/fasolt.client/public/sitemap.xml
+++ b/fasolt.client/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://fasolt.app/</loc>
+  </url>
+  <url>
+    <loc>https://fasolt.app/algorithm</loc>
+  </url>
+  <url>
+    <loc>https://fasolt.app/privacy</loc>
+  </url>
+</urlset>

--- a/fasolt.client/src/__tests__/router.test.ts
+++ b/fasolt.client/src/__tests__/router.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const authState = {
+  isLoading: false,
+  isAuthenticated: false,
+  isEmailConfirmed: false,
+  isAdmin: false,
+  fetchUser: vi.fn(),
+}
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => authState,
+}))
+
+describe('router document titles', () => {
+  afterEach(() => {
+    authState.isLoading = false
+    authState.isAuthenticated = false
+    authState.isEmailConfirmed = false
+    authState.isAdmin = false
+    authState.fetchUser.mockReset()
+    document.title = ''
+    vi.resetModules()
+  })
+
+  it('formats the app title consistently', async () => {
+    const { formatDocumentTitle } = await import('@/router')
+    expect(formatDocumentTitle('Cards')).toBe('Cards - fasolt')
+    expect(formatDocumentTitle(undefined)).toBe('fasolt')
+  })
+
+  it('updates document.title after navigation', async () => {
+    const { default: router } = await import('@/router')
+    await router.push('/algorithm')
+    await router.isReady()
+
+    expect(document.title).toBe('FSRS algorithm - fasolt')
+  })
+})

--- a/fasolt.client/src/env.d.ts
+++ b/fasolt.client/src/env.d.ts
@@ -1,1 +1,18 @@
-declare const __APP_VERSION__: string
+import 'vue-router'
+
+declare global {
+  const __APP_VERSION__: string
+}
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    public?: boolean
+    authRedirect?: boolean
+    landing?: boolean
+    skipVerificationCheck?: boolean
+    requiresAdmin?: boolean
+    title?: string
+  }
+}
+
+export {}

--- a/fasolt.client/src/router/index.ts
+++ b/fasolt.client/src/router/index.ts
@@ -2,6 +2,12 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import StudyView from '@/views/StudyView.vue'
 
+const appName = 'fasolt'
+
+function formatDocumentTitle(title?: string) {
+  return title ? `${title} - ${appName}` : appName
+}
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -10,85 +16,85 @@ const router = createRouter({
       path: '/login',
       name: 'login',
       component: () => import('@/views/LoginView.vue'),
-      meta: { public: true, authRedirect: true },
+      meta: { public: true, authRedirect: true, title: 'Log in' },
     },
     {
       path: '/register',
       name: 'register',
       component: () => import('@/views/RegisterView.vue'),
-      meta: { public: true, authRedirect: true },
+      meta: { public: true, authRedirect: true, title: 'Create account' },
     },
     {
       path: '/forgot-password',
       name: 'forgot-password',
       component: () => import('@/views/ForgotPasswordView.vue'),
-      meta: { public: true },
+      meta: { public: true, title: 'Forgot password' },
     },
     {
       path: '/reset-password',
       name: 'reset-password',
       component: () => import('@/views/ResetPasswordView.vue'),
-      meta: { public: true },
+      meta: { public: true, title: 'Reset password' },
     },
     {
       path: '/verify-email',
       name: 'verify-email',
       component: () => import('@/views/EmailVerificationView.vue'),
-      meta: { requiresAuth: true, skipVerificationCheck: true },
+      meta: { requiresAuth: true, skipVerificationCheck: true, title: 'Verify email' },
     },
     {
       path: '/confirm-email',
       name: 'confirm-email',
       component: () => import('@/views/ConfirmEmailView.vue'),
-      meta: { public: true },
+      meta: { public: true, title: 'Confirm email' },
     },
     {
       path: '/confirm-email-change',
       name: 'confirm-email-change',
       component: () => import('@/views/ConfirmEmailChangeView.vue'),
-      meta: { skipVerificationCheck: true },
+      meta: { skipVerificationCheck: true, title: 'Confirm email change' },
     },
     {
       path: '/oauth/consent',
       name: 'oauth-consent',
       component: () => import('@/views/OAuthConsentView.vue'),
-      meta: { public: true },
+      meta: { public: true, title: 'Authorize app' },
     },
     // Landing page (public)
     {
       path: '/',
       name: 'landing',
       component: () => import('@/views/LandingView.vue'),
-      meta: { public: true, authRedirect: true, landing: true },
+      meta: { public: true, authRedirect: true, landing: true, title: 'MCP-first spaced repetition for markdown notes' },
     },
     {
       path: '/algorithm',
       name: 'algorithm',
       component: () => import('@/views/AlgorithmView.vue'),
-      meta: { public: true, landing: true },
+      meta: { public: true, landing: true, title: 'FSRS algorithm' },
     },
     {
       path: '/privacy',
       name: 'privacy',
       component: () => import('@/views/PrivacyPolicyView.vue'),
-      meta: { public: true, landing: true },
+      meta: { public: true, landing: true, title: 'Privacy policy' },
     },
     // App routes (require auth)
-    { path: '/study', name: 'study', component: StudyView },
-    { path: '/sources', name: 'sources', component: () => import('@/views/SourcesView.vue') },
-    { path: '/cards', name: 'cards', component: () => import('@/views/CardsView.vue') },
-    { path: '/cards/:id', name: 'card-detail', component: () => import('@/views/CardDetailView.vue') },
-    { path: '/decks', name: 'decks', component: () => import('@/views/DecksView.vue') },
-    { path: '/decks/:id', name: 'deck-detail', component: () => import('@/views/DeckDetailView.vue') },
-    { path: '/decks/:id/snapshots', name: 'deck-snapshots', component: () => import('@/views/DeckSnapshotsView.vue') },
-    { path: '/decks/:id/snapshots/:snapshotId/restore', name: 'restore-snapshot', component: () => import('@/views/RestoreSnapshotView.vue') },
-    { path: '/review/:deckId?', name: 'review', component: () => import('@/views/ReviewView.vue') },
-    { path: '/mcp-setup', name: 'mcp', component: () => import('@/views/McpView.vue') },
-    { path: '/settings', name: 'settings', component: () => import('@/views/SettingsView.vue') },
-    { path: '/admin', name: 'admin', component: () => import('@/views/AdminView.vue'), meta: { requiresAdmin: true } },
+    { path: '/study', name: 'study', component: StudyView, meta: { title: 'Study' } },
+    { path: '/sources', name: 'sources', component: () => import('@/views/SourcesView.vue'), meta: { title: 'Sources' } },
+    { path: '/cards', name: 'cards', component: () => import('@/views/CardsView.vue'), meta: { title: 'Cards' } },
+    { path: '/cards/:id', name: 'card-detail', component: () => import('@/views/CardDetailView.vue'), meta: { title: 'Card details' } },
+    { path: '/decks', name: 'decks', component: () => import('@/views/DecksView.vue'), meta: { title: 'Decks' } },
+    { path: '/decks/:id', name: 'deck-detail', component: () => import('@/views/DeckDetailView.vue'), meta: { title: 'Deck details' } },
+    { path: '/decks/:id/snapshots', name: 'deck-snapshots', component: () => import('@/views/DeckSnapshotsView.vue'), meta: { title: 'Deck snapshots' } },
+    { path: '/decks/:id/snapshots/:snapshotId/restore', name: 'restore-snapshot', component: () => import('@/views/RestoreSnapshotView.vue'), meta: { title: 'Restore snapshot' } },
+    { path: '/review/:deckId?', name: 'review', component: () => import('@/views/ReviewView.vue'), meta: { title: 'Review' } },
+    { path: '/mcp-setup', name: 'mcp', component: () => import('@/views/McpView.vue'), meta: { title: 'MCP setup' } },
+    { path: '/settings', name: 'settings', component: () => import('@/views/SettingsView.vue'), meta: { title: 'Settings' } },
+    { path: '/admin', name: 'admin', component: () => import('@/views/AdminView.vue'), meta: { requiresAdmin: true, title: 'Admin' } },
     { path: '/dashboard', redirect: '/study' },
     // Catch-all 404
-    { path: '/:pathMatch(.*)*', name: 'not-found', component: () => import('@/views/NotFoundView.vue'), meta: { public: true } },
+    { path: '/:pathMatch(.*)*', name: 'not-found', component: () => import('@/views/NotFoundView.vue'), meta: { public: true, title: 'Page not found' } },
   ],
 })
 
@@ -127,4 +133,9 @@ router.beforeEach(async (to) => {
   }
 })
 
+router.afterEach((to) => {
+  document.title = formatDocumentTitle(to.meta.title)
+})
+
 export default router
+export { formatDocumentTitle }


### PR DESCRIPTION
## Summary
- add base SEO metadata to the Vite app shell with a description and theme color
- add static discovery files for crawlers and agents: `robots.txt`, `sitemap.xml`, and `llms.txt`
- implement dynamic page titles in the Vue router for public and authenticated routes
- add a router test covering title formatting and document title updates

## Test plan
- cd fasolt.client && npm run test
- cd fasolt.client && npm run build
- verify `http://localhost:5173/robots.txt`, `/sitemap.xml`, and `/llms.txt` load in the running frontend
