### PR TITLE
Fix iOS logout: disable rolling refresh tokens, fix session invalidation

### DIFF
--- a/fasolt.Server/Program.cs
+++ b/fasolt.Server/Program.cs
@@ -117,7 +117,8 @@ builder.Services.AddOpenIddict()
                .DisableTransportSecurityRequirement();
 
         options.SetAccessTokenLifetime(TimeSpan.FromHours(1))
-               .SetRefreshTokenLifetime(TimeSpan.FromDays(14));
+               .SetRefreshTokenLifetime(TimeSpan.FromDays(14))
+               .DisableRollingRefreshTokens();
 
         // Accept any resource parameter from MCP clients (single-tenant, we are the resource server)
         options.DisableResourceValidation();

--- a/fasolt.ios/Fasolt/FasoltApp.swift
+++ b/fasolt.ios/Fasolt/FasoltApp.swift
@@ -87,4 +87,5 @@ struct FasoltApp: App {
 extension Notification.Name {
     static let appDidBecomeActive = Notification.Name("appDidBecomeActive")
     static let studySessionEnded = Notification.Name("studySessionEnded")
+    static let sessionDidInvalidate = Notification.Name("sessionDidInvalidate")
 }

--- a/fasolt.ios/Fasolt/Services/APIClient.swift
+++ b/fasolt.ios/Fasolt/Services/APIClient.swift
@@ -10,7 +10,6 @@ actor APIClient {
     private let decoder: JSONDecoder
 
     private var refreshTask: Task<Bool, Error>?
-    private var onAuthFailure: (@Sendable () -> Void)?
 
     init(session: URLSession = .shared, keychain: KeychainHelper = KeychainHelper()) {
         self.session = session
@@ -23,8 +22,9 @@ actor APIClient {
         keychain.retrieve("fasolt.serverURL")
     }
 
-    func setAuthFailureHandler(_ handler: @escaping @Sendable () -> Void) {
-        onAuthFailure = handler
+    /// Broadcasts session invalidation so AuthService (or any observer) can react.
+    nonisolated private func broadcastSessionInvalidation() {
+        NotificationCenter.default.post(name: .sessionDidInvalidate, object: nil)
     }
 
     // MARK: - Authenticated requests
@@ -105,7 +105,7 @@ actor APIClient {
                 // Transient network failures preserve tokens for later retry.
                 if keychain.retrieve("fasolt.refreshToken") == nil {
                     apiLogger.error("No valid credentials — triggering auth failure")
-                    onAuthFailure?()
+                    broadcastSessionInvalidation()
                 }
                 throw APIError.unauthorized
             }
@@ -134,7 +134,7 @@ actor APIClient {
                 // If tokens still exist, it was a transient network failure — don't destroy the session.
                 if keychain.retrieve("fasolt.refreshToken") == nil {
                     apiLogger.error("Token refresh failed (session invalid) — triggering auth failure")
-                    onAuthFailure?()
+                    broadcastSessionInvalidation()
                 }
                 throw APIError.unauthorized
             }
@@ -225,27 +225,27 @@ actor APIClient {
                 return true
             } catch let error as APIError {
                 switch error {
-                case .networkError:
-                    // Transient — retry after a short delay
-                    apiLogger.warning("Token refresh network error (attempt \(attempt)/3)")
+                case .networkError, .serverError:
+                    // Transient — retry after a short delay (network issues or server hiccups
+                    // shouldn't destroy the session)
+                    apiLogger.warning("Token refresh transient error (attempt \(attempt)/3): \(error)")
                     if attempt < 3 {
                         try? await Task.sleep(for: .seconds(2 * attempt))
                     }
-                case .unauthorized, .forbidden:
+                case .unauthorized, .forbidden, .badRequest:
                     // Server explicitly rejected the refresh token — session is invalid
                     apiLogger.error("Token refresh rejected by server: \(error)")
                     keychain.delete("fasolt.accessToken")
                     keychain.delete("fasolt.refreshToken")
                     keychain.delete("fasolt.tokenExpiry")
-                    onAuthFailure?()
+                    broadcastSessionInvalidation()
                     return false
                 default:
-                    // Other server errors (400, 500) — likely the token is bad
                     apiLogger.error("Token refresh failed: \(error)")
                     keychain.delete("fasolt.accessToken")
                     keychain.delete("fasolt.refreshToken")
                     keychain.delete("fasolt.tokenExpiry")
-                    onAuthFailure?()
+                    broadcastSessionInvalidation()
                     return false
                 }
             } catch {

--- a/fasolt.ios/Fasolt/Services/AuthService.swift
+++ b/fasolt.ios/Fasolt/Services/AuthService.swift
@@ -16,6 +16,7 @@ final class AuthService {
     let keychain: KeychainHelper
     let apiClient: APIClient
     private var activeAuthSession: ASWebAuthenticationSession?
+    private var sessionInvalidationObserver: Any?
 
     static let redirectURI = "fasolt://oauth/callback"
     static let firstPartyClientId = "fasolt-ios"
@@ -35,15 +36,16 @@ final class AuthService {
             return true
         }()
 
-        // Force logout when token refresh fails so the user isn't stuck on authenticated screens
-        Task { [weak self] in
-            await apiClient.setAuthFailureHandler { [weak self] in
-                Task { @MainActor [weak self] in
-                    guard let self, self.isAuthenticated else { return }
-                    authLogger.warning("Token refresh failed — forcing logout")
-                    self.isAuthenticated = false
-                }
-            }
+        // Force logout when token refresh fails so the user isn't stuck on authenticated screens.
+        // Uses NotificationCenter (synchronous, no race condition) instead of an async closure.
+        sessionInvalidationObserver = NotificationCenter.default.addObserver(
+            forName: .sessionDidInvalidate,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, self.isAuthenticated else { return }
+            authLogger.warning("Session invalidated — forcing logout")
+            self.isAuthenticated = false
         }
     }
 


### PR DESCRIPTION
## Summary

- **Disable rolling refresh tokens** in OpenIddict ��� eliminates reuse detection that revokes all tokens when a response is lost during network instability (common on iOS foregrounding)
- **Treat server errors (500+) as transient** in token refresh — retry instead of destroying the session
- **Replace async closure with NotificationCenter** for session invalidation — fixes race condition where the `onAuthFailure` handler wasn't set up before the first API call

## Root Cause

Three issues combined to cause unexpected logouts on iOS:

1. OpenIddict's default rolling refresh tokens consume the old token on each use. If the iOS app sends a refresh but the response is lost (WiFi reconnecting after backgrounding), the retry triggers reuse detection, which revokes the entire authorization chain.

2. The `doRefreshToken` error handler treated ALL non-network errors (including transient 500s) as session invalidation, clearing tokens and forcing logout.

3. The `onAuthFailure` closure was set asynchronously via `Task { await apiClient.setAuthFailureHandler(...) }`. If the first API call reached the actor before this Task executed, the handler was nil and the logout notification never fired — leaving the user on authenticated screens with all API calls failing.

## Test plan

- [ ] Backend: `dotnet test` — 173 tests pass
- [ ] iOS: `xcodebuild test` — 29 tests pass
- [ ] iOS: Log in, background app for >1 hour, return — should stay logged in
- [ ] iOS: Revoke session server-side — app should redirect to login screen immediately
- [ ] iOS: Kill and relaunch app with expired access token — should refresh and work normally

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)