### PR TITLE
iOS: deep link push notifications to the study screen

### DIFF
--- a/fasolt.ios/Fasolt/FasoltApp.swift
+++ b/fasolt.ios/Fasolt/FasoltApp.swift
@@ -5,7 +5,7 @@ import os
 
 private let appLogger = Logger(subsystem: "com.fasolt.app", category: "AppDelegate")
 
-class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotificationCenterDelegate {
     var onDeviceToken: ((Data) -> Void)?
 
     func application(_ application: UIApplication,
@@ -28,19 +28,19 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
     // Show notifications as banners even when app is in foreground.
     func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                willPresent notification: UNNotification) async
-        -> UNNotificationPresentationOptions {
-        [.banner, .sound, .badge]
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound, .badge])
     }
 
     // Handle user tapping a notification — deep link into the study screen.
     func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                didReceive response: UNNotificationResponse) async {
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        defer { completionHandler() }
         guard response.actionIdentifier == UNNotificationDefaultActionIdentifier else { return }
         appLogger.info("Notification tapped — requesting study view")
-        await MainActor.run {
-            NavigationRouter.shared.pendingDeepLink = .study
-        }
+        NavigationRouter.shared.pendingDeepLink = .study
     }
 }
 

--- a/fasolt.ios/Fasolt/FasoltApp.swift
+++ b/fasolt.ios/Fasolt/FasoltApp.swift
@@ -1,11 +1,18 @@
 import SwiftUI
 import SwiftData
+import UserNotifications
 import os
 
 private let appLogger = Logger(subsystem: "com.fasolt.app", category: "AppDelegate")
 
-class AppDelegate: NSObject, UIApplicationDelegate {
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     var onDeviceToken: ((Data) -> Void)?
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
 
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -18,6 +25,40 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                      didFailToRegisterForRemoteNotificationsWithError error: Error) {
         appLogger.error("Remote notification registration failed: \(error)")
     }
+
+    // Show notifications as banners even when app is in foreground.
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification) async
+        -> UNNotificationPresentationOptions {
+        [.banner, .sound, .badge]
+    }
+
+    // Handle user tapping a notification — deep link into the study screen.
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse) async {
+        guard response.actionIdentifier == UNNotificationDefaultActionIdentifier else { return }
+        appLogger.info("Notification tapped — requesting study view")
+        await MainActor.run {
+            NavigationRouter.shared.pendingDeepLink = .study
+        }
+    }
+}
+
+/// Holds a pending deep link request so that navigation survives between the
+/// notification delegate callback (which may fire during cold launch before
+/// SwiftUI views have mounted) and the view hierarchy becoming ready.
+@MainActor
+@Observable
+final class NavigationRouter {
+    static let shared = NavigationRouter()
+
+    enum DeepLink: Equatable {
+        case study
+    }
+
+    var pendingDeepLink: DeepLink?
+
+    private init() {}
 }
 
 @main

--- a/fasolt.ios/Fasolt/Views/MainTabView.swift
+++ b/fasolt.ios/Fasolt/Views/MainTabView.swift
@@ -12,6 +12,7 @@ struct MainTabView: View {
     @State private var notificationService: NotificationService?
     @State private var showStudy = false
     @State private var studyDeckId: String?
+    @State private var selectedTab: Int = 0
     @State private var router = NavigationRouter.shared
 
     var body: some View {
@@ -23,13 +24,14 @@ struct MainTabView: View {
                     return vm
                 }
 
-                TabView {
+                TabView(selection: $selectedTab) {
                     DashboardView(
                         viewModel: DashboardViewModel(apiClient: authService.apiClient, deckRepository: deckRepository)
                     )
                     .tabItem {
                         Label("Study", systemImage: "book.fill")
                     }
+                    .tag(0)
 
                     LibraryView(
                         deckListViewModel: DeckListViewModel(deckRepository: deckRepository),
@@ -44,6 +46,7 @@ struct MainTabView: View {
                     .tabItem {
                         Label("Library", systemImage: "books.vertical.fill")
                     }
+                    .tag(1)
 
                     SettingsView(
                         viewModel: SettingsViewModel(apiClient: authService.apiClient),
@@ -54,6 +57,7 @@ struct MainTabView: View {
                     .tabItem {
                         Label("Settings", systemImage: "gear")
                     }
+                    .tag(2)
                 }
                 .fullScreenCover(isPresented: $showStudy, onDismiss: {
                     studyDeckId = nil
@@ -105,13 +109,8 @@ struct MainTabView: View {
         guard let deepLink = router.pendingDeepLink else { return }
         switch deepLink {
         case .study:
-            // Clear first so tapping the notification again after dismissing
-            // study can trigger another navigation.
             router.pendingDeepLink = nil
-            // Avoid re-presenting while a study session is already on screen.
-            guard !showStudy else { return }
-            studyDeckId = nil
-            showStudy = true
+            selectedTab = 0
         }
     }
 }

--- a/fasolt.ios/Fasolt/Views/MainTabView.swift
+++ b/fasolt.ios/Fasolt/Views/MainTabView.swift
@@ -12,6 +12,7 @@ struct MainTabView: View {
     @State private var notificationService: NotificationService?
     @State private var showStudy = false
     @State private var studyDeckId: String?
+    @State private var router = NavigationRouter.shared
 
     var body: some View {
         Group {
@@ -66,6 +67,12 @@ struct MainTabView: View {
                     studyDeckId = deckId
                     showStudy = true
                 })
+                .onAppear {
+                    handlePendingDeepLink()
+                }
+                .onChange(of: router.pendingDeepLink) { _, _ in
+                    handlePendingDeepLink()
+                }
             } else {
                 ProgressView()
             }
@@ -91,6 +98,20 @@ struct MainTabView: View {
             )
             syncService = service
             await service.startMonitoring()
+        }
+    }
+
+    private func handlePendingDeepLink() {
+        guard let deepLink = router.pendingDeepLink else { return }
+        switch deepLink {
+        case .study:
+            // Clear first so tapping the notification again after dismissing
+            // study can trigger another navigation.
+            router.pendingDeepLink = nil
+            // Avoid re-presenting while a study session is already on screen.
+            guard !showStudy else { return }
+            studyDeckId = nil
+            showStudy = true
         }
     }
 }

--- a/fasolt.ios/Fasolt/Views/Study/StudySummaryView.swift
+++ b/fasolt.ios/Fasolt/Views/Study/StudySummaryView.swift
@@ -8,43 +8,55 @@ struct StudySummaryView: View {
     var suspendedCount: Int = 0
     let onDone: () -> Void
 
+    private var isEmptySession: Bool {
+        cardsStudied == 0 && skippedCount == 0 && suspendedCount == 0
+    }
+
     var body: some View {
         VStack(spacing: 24) {
             Spacer()
 
-            Image(systemName: "checkmark.circle.fill")
+            Image(systemName: isEmptySession ? "sparkles" : "checkmark.circle.fill")
                 .font(.system(size: 56))
-                .foregroundStyle(.green)
+                .foregroundStyle(isEmptySession ? .blue : .green)
 
-            Text("Session Complete")
+            Text(isEmptySession ? "All caught up!" : "Session Complete")
                 .font(.title2.bold())
 
-            VStack(spacing: 12) {
-                HStack {
-                    Text("Cards studied")
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                    Text("\(cardsStudied)")
-                        .fontWeight(.semibold)
+            if isEmptySession {
+                Text("No cards are due for review right now.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            } else {
+                VStack(spacing: 12) {
+                    HStack {
+                        Text("Cards studied")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("\(cardsStudied)")
+                            .fontWeight(.semibold)
+                    }
+
+                    Divider()
+
+                    ratingRow("Again", count: ratingsCount["again"] ?? 0, color: .red)
+                    ratingRow("Hard", count: ratingsCount["hard"] ?? 0, color: .orange)
+                    ratingRow("Good", count: ratingsCount["good"] ?? 0, color: .green)
+                    ratingRow("Easy", count: ratingsCount["easy"] ?? 0, color: .blue)
+
+                    if skippedCount > 0 {
+                        ratingRow("Skipped", count: skippedCount, color: .gray)
+                    }
+
+                    if suspendedCount > 0 {
+                        ratingRow("Suspended", count: suspendedCount, color: .gray)
+                    }
                 }
-
-                Divider()
-
-                ratingRow("Again", count: ratingsCount["again"] ?? 0, color: .red)
-                ratingRow("Hard", count: ratingsCount["hard"] ?? 0, color: .orange)
-                ratingRow("Good", count: ratingsCount["good"] ?? 0, color: .green)
-                ratingRow("Easy", count: ratingsCount["easy"] ?? 0, color: .blue)
-
-                if skippedCount > 0 {
-                    ratingRow("Skipped", count: skippedCount, color: .gray)
-                }
-
-                if suspendedCount > 0 {
-                    ratingRow("Suspended", count: suspendedCount, color: .gray)
-                }
+                .padding()
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
             }
-            .padding()
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
 
             if failedRatings > 0 {
                 Label(

--- a/fasolt.ios/Fasolt/Views/Study/StudySummaryView.swift
+++ b/fasolt.ios/Fasolt/Views/Study/StudySummaryView.swift
@@ -8,55 +8,43 @@ struct StudySummaryView: View {
     var suspendedCount: Int = 0
     let onDone: () -> Void
 
-    private var isEmptySession: Bool {
-        cardsStudied == 0 && skippedCount == 0 && suspendedCount == 0
-    }
-
     var body: some View {
         VStack(spacing: 24) {
             Spacer()
 
-            Image(systemName: isEmptySession ? "sparkles" : "checkmark.circle.fill")
+            Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 56))
-                .foregroundStyle(isEmptySession ? .blue : .green)
+                .foregroundStyle(.green)
 
-            Text(isEmptySession ? "All caught up!" : "Session Complete")
+            Text("Session Complete")
                 .font(.title2.bold())
 
-            if isEmptySession {
-                Text("No cards are due for review right now.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
-            } else {
-                VStack(spacing: 12) {
-                    HStack {
-                        Text("Cards studied")
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        Text("\(cardsStudied)")
-                            .fontWeight(.semibold)
-                    }
-
-                    Divider()
-
-                    ratingRow("Again", count: ratingsCount["again"] ?? 0, color: .red)
-                    ratingRow("Hard", count: ratingsCount["hard"] ?? 0, color: .orange)
-                    ratingRow("Good", count: ratingsCount["good"] ?? 0, color: .green)
-                    ratingRow("Easy", count: ratingsCount["easy"] ?? 0, color: .blue)
-
-                    if skippedCount > 0 {
-                        ratingRow("Skipped", count: skippedCount, color: .gray)
-                    }
-
-                    if suspendedCount > 0 {
-                        ratingRow("Suspended", count: suspendedCount, color: .gray)
-                    }
+            VStack(spacing: 12) {
+                HStack {
+                    Text("Cards studied")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(cardsStudied)")
+                        .fontWeight(.semibold)
                 }
-                .padding()
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+
+                Divider()
+
+                ratingRow("Again", count: ratingsCount["again"] ?? 0, color: .red)
+                ratingRow("Hard", count: ratingsCount["hard"] ?? 0, color: .orange)
+                ratingRow("Good", count: ratingsCount["good"] ?? 0, color: .green)
+                ratingRow("Easy", count: ratingsCount["easy"] ?? 0, color: .blue)
+
+                if skippedCount > 0 {
+                    ratingRow("Skipped", count: skippedCount, color: .gray)
+                }
+
+                if suspendedCount > 0 {
+                    ratingRow("Suspended", count: suspendedCount, color: .gray)
+                }
             }
+            .padding()
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
 
             if failedRatings > 0 {
                 Label(


### PR DESCRIPTION
Tapping an APNs notification now launches the app directly into the
full-screen study view instead of the last-visited tab. Handled via a
new NavigationRouter singleton that buffers the deep link across the
UNUserNotificationCenterDelegate callback and the SwiftUI view mounting
lifecycle, so cold launches from a notification tap are not lost.

Also surfaces a friendly "All caught up!" empty state in
StudySummaryView when a session starts with no due cards (the main
edge case when a notification is tapped after the cards have already
been reviewed elsewhere).

Closes #105