### PR TITLE
Add Claude Code cloud environment setup and session hooks

### DIFF
--- a/.claude/session-start.sh
+++ b/.claude/session-start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Claude Code SessionStart hook — runs every session (new + resumed).
+# Handles project-level dependencies and services.
+set -e
+cd "$(dirname "$0")/.."
+
+# Only run in cloud sessions
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  exit 0
+fi
+
+# Ensure .env exists
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+# Start PostgreSQL if not running
+if ! pg_isready -q 2>/dev/null; then
+  sudo pg_ctlcluster 17 main start || true
+fi
+
+# Restore backend dependencies
+dotnet restore --verbosity quiet
+
+# Install frontend dependencies
+cd fasolt.client && npm install --silent

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,20 @@
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "DOTNET_ROOT": "/usr/share/dotnet"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/session-start.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,

--- a/.claude/setup.sh
+++ b/.claude/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Claude Code on the Web — Setup Script
+# Paste this into the cloud environment "Setup script" field.
+# Runs once as root on Ubuntu 24.04 when a new session starts.
+set -e
+
+# --- .NET 10 SDK ---
+wget -q https://dot.net/v1/dotnet-install.sh -O /tmp/dotnet-install.sh
+chmod +x /tmp/dotnet-install.sh
+/tmp/dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet
+ln -sf /usr/share/dotnet/dotnet /usr/local/bin/dotnet
+export DOTNET_ROOT=/usr/share/dotnet
+
+# --- Node.js 22 ---
+curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+apt-get install -y nodejs
+
+# --- PostgreSQL 17 ---
+apt-get install -y gnupg lsb-release curl ca-certificates
+echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+  > /etc/apt/sources.list.d/pgdg.list
+curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+apt-get update
+apt-get install -y postgresql-17
+
+# Start PostgreSQL and create the dev database
+pg_ctlcluster 17 main start
+su - postgres -c "psql -c \"CREATE USER fasolt WITH PASSWORD 'fasolt_dev';\"" || true
+su - postgres -c "psql -c \"CREATE DATABASE fasolt OWNER fasolt;\"" || true
+su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE fasolt TO fasolt;\"" || true


### PR DESCRIPTION
## Summary
This PR adds configuration and automation scripts to support running the Fasolt project in Claude Code's cloud environment. It includes a one-time setup script for installing dependencies and a session start hook for project initialization.

## Key Changes
- **`.claude/setup.sh`**: New setup script that runs once when a cloud session starts as root. Installs:
  - .NET 10 SDK with proper symlinks and environment variables
  - Node.js 22 via NodeSource repository
  - PostgreSQL 17 with initial database and user creation (`fasolt` user/database)

- **`.claude/session-start.sh`**: New session start hook that runs on every session (new and resumed). Handles:
  - Conditional execution only in cloud environments via `CLAUDE_CODE_REMOTE` check
  - `.env` file initialization from `.env.example`
  - PostgreSQL service startup verification
  - Backend dependency restoration via `dotnet restore`
  - Frontend dependency installation via `npm install`

- **`.claude/settings.json`**: Updated configuration to:
  - Add `DOTNET_ROOT` environment variable pointing to the .NET installation
  - Register the session start hook with a 120-second timeout

## Implementation Details
- The setup script uses `set -e` to fail fast on errors and includes `|| true` guards for idempotent database operations
- The session start hook only executes in cloud environments to avoid interference with local development
- Both scripts are designed to be idempotent where possible (e.g., PostgreSQL start, database creation)
- The session hook restores dependencies before starting the frontend build to ensure consistency

https://claude.ai/code/session_016VFPy9oabGpR8amCvRJaii