### PR TITLE
Admin: delete user and all their data

### DIFF
--- a/fasolt.Server/Api/Endpoints/AdminEndpoints.cs
+++ b/fasolt.Server/Api/Endpoints/AdminEndpoints.cs
@@ -14,6 +14,7 @@ public static class AdminEndpoints
         group.MapGet("/users", ListUsers);
         group.MapPost("/users/{id}/lock", LockUser);
         group.MapPost("/users/{id}/unlock", UnlockUser);
+        group.MapDelete("/users/{id}", DeleteUser);
         group.MapGet("/logs", GetLogs);
         group.MapPost("/users/{id}/push", TriggerPushForUser);
     }
@@ -32,7 +33,8 @@ public static class AdminEndpoints
     private static async Task<IResult> LockUser(
         string id,
         ClaimsPrincipal principal,
-        UserManager<AppUser> userManager)
+        UserManager<AppUser> userManager,
+        AdminService adminService)
     {
         var currentUser = await userManager.GetUserAsync(principal);
         if (currentUser is null) return Results.Unauthorized();
@@ -45,19 +47,22 @@ public static class AdminEndpoints
 
         await userManager.SetLockoutEnabledAsync(user, true);
         await userManager.SetLockoutEndDateAsync(user, DateTimeOffset.MaxValue);
+        await adminService.LogAdminAction($"User locked: {user.Email}");
 
         return Results.Ok();
     }
 
     private static async Task<IResult> UnlockUser(
         string id,
-        UserManager<AppUser> userManager)
+        UserManager<AppUser> userManager,
+        AdminService adminService)
     {
         var user = await userManager.FindByIdAsync(id);
         if (user is null) return Results.NotFound();
 
         await userManager.SetLockoutEndDateAsync(user, null);
         await userManager.ResetAccessFailedCountAsync(user);
+        await adminService.LogAdminAction($"User unlocked: {user.Email}");
 
         return Results.Ok();
     }
@@ -72,6 +77,29 @@ public static class AdminEndpoints
         var ps = Math.Clamp(pageSize ?? 50, 1, 100);
         var result = await adminService.GetLogs(p, ps, type);
         return Results.Ok(result);
+    }
+
+    private static async Task<IResult> DeleteUser(
+        string id,
+        ClaimsPrincipal principal,
+        UserManager<AppUser> userManager,
+        AccountDataService accountDataService,
+        AdminService adminService)
+    {
+        var currentUser = await userManager.GetUserAsync(principal);
+        if (currentUser is null) return Results.Unauthorized();
+
+        if (currentUser.Id == id)
+            return Results.BadRequest(new { error = "Cannot delete your own account." });
+
+        var user = await userManager.FindByIdAsync(id);
+        if (user is null) return Results.NotFound();
+
+        var email = user.Email;
+        await accountDataService.DeleteUserData(user.Id);
+        await adminService.LogAdminAction($"User deleted: {email}");
+
+        return Results.Ok();
     }
 
     private static async Task<IResult> TriggerPushForUser(

--- a/fasolt.Server/Application/Services/AdminService.cs
+++ b/fasolt.Server/Application/Services/AdminService.cs
@@ -48,6 +48,18 @@ public class AdminService(AppDbContext db, ApnsService? apnsService = null)
         return new LogListResponse(logs, total, page, pageSize);
     }
 
+    public async Task LogAdminAction(string message)
+    {
+        db.Logs.Add(new AppLog
+        {
+            Type = LogType.Admin,
+            Message = message,
+            Success = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync();
+    }
+
     public async Task<PushResult?> TriggerPushForUser(string userId)
     {
         if (apnsService is null) return null;

--- a/fasolt.Server/Domain/Entities/AppLog.cs
+++ b/fasolt.Server/Domain/Entities/AppLog.cs
@@ -3,6 +3,7 @@ namespace Fasolt.Server.Domain.Entities;
 public enum LogType
 {
     Notification,
+    Admin,
 }
 
 public class AppLog

--- a/fasolt.client/src/views/AdminView.vue
+++ b/fasolt.client/src/views/AdminView.vue
@@ -57,6 +57,8 @@ const pageSize = 50
 const isLoading = ref(false)
 const lockDialogOpen = ref(false)
 const lockTargetUser = ref<AdminUser | null>(null)
+const deleteDialogOpen = ref(false)
+const deleteTargetUser = ref<AdminUser | null>(null)
 const errorMessage = ref<string | null>(null)
 
 const logs = ref<LogEntry[]>([])
@@ -131,6 +133,23 @@ async function pushToUser(user: AdminUser) {
     errorMessage.value = e.message ?? 'Failed to send push'
   } finally {
     pushingUserId.value = null
+  }
+}
+
+function confirmDelete(user: AdminUser) {
+  deleteTargetUser.value = user
+  deleteDialogOpen.value = true
+}
+
+async function deleteUser() {
+  if (!deleteTargetUser.value) return
+  try {
+    await apiFetch(`/admin/users/${deleteTargetUser.value.id}`, { method: 'DELETE' })
+    deleteDialogOpen.value = false
+    await fetchUsers()
+  } catch (e: any) {
+    errorMessage.value = e.message ?? 'Failed to delete user'
+    console.error('Failed to delete user', e)
   }
 }
 
@@ -251,6 +270,9 @@ onMounted(() => {
               <Button v-else variant="outline" size="sm" @click="unlockUser(u.id)">
                 Unlock
               </Button>
+              <Button variant="destructive" size="sm" @click="confirmDelete(u)">
+                Delete
+              </Button>
             </TableCell>
           </TableRow>
         </TableBody>
@@ -344,6 +366,22 @@ onMounted(() => {
         <DialogFooter class="gap-2">
           <Button variant="outline" size="sm" @click="lockDialogOpen = false">Cancel</Button>
           <Button variant="destructive" size="sm" @click="lockUser">Lock Account</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
+    <!-- Delete confirmation dialog -->
+    <Dialog v-model:open="deleteDialogOpen">
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete user account?</DialogTitle>
+          <DialogDescription>
+            This will permanently delete {{ deleteTargetUser?.displayName || deleteTargetUser?.email }} and all their data including cards, decks, review history, and notification tokens. This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter class="gap-2">
+          <Button variant="outline" size="sm" @click="deleteDialogOpen = false">Cancel</Button>
+          <Button variant="destructive" size="sm" @click="deleteUser">Delete Account</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

- Add `DELETE /api/admin/users/{id}` endpoint with self-deletion prevention
- Add Delete button and confirmation dialog to admin user list
- Reuses `AccountDataService.DeleteUserData` for OpenIddict cleanup + cascade deletes

Closes #114

## Test plan

- [x] Delete button visible for all users in admin table
- [x] Confirmation dialog shows user email and warns deletion is irreversible
- [x] Deleting another user succeeds, user removed from list
- [x] Deleting own account returns error, error banner displayed
- [x] Backend builds, all 267 tests pass
- [x] Playwright browser testing confirmed all flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)