### PR TITLE
Reframe landing page for non-technical visitors

### DIFF
--- a/fasolt.client/src/components/FasoltStudyPreview.vue
+++ b/fasolt.client/src/components/FasoltStudyPreview.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+
+const cards = [
+  {
+    front: 'What does a tokenizer do and why is it needed?',
+    back: 'Splits text into tokens (numeric IDs) that LLMs operate on, instead of raw characters.',
+    rating: 2, // Good
+  },
+  {
+    front: 'What is the context window of an LLM?',
+    back: 'The maximum number of tokens the model can attend to at once when generating a response.',
+    rating: 3, // Easy
+  },
+  {
+    front: 'How does temperature affect text generation?',
+    back: 'Higher = more random and creative. Lower = more focused and deterministic.',
+    rating: 1, // Hard
+  },
+]
+const totalInDeck = 7
+
+const currentIndex = ref(0)
+const isFlipped = ref(false)
+const showRating = ref(false)
+const highlightedRating = ref<number | null>(null)
+const isExiting = ref(false)
+
+const card = computed(() => cards[currentIndex.value])
+const progressPct = computed(() => {
+  const completed = currentIndex.value + (showRating.value ? 1 : 0)
+  return Math.min(100, Math.round((completed / totalInDeck) * 100))
+})
+
+const timers: ReturnType<typeof setTimeout>[] = []
+const reducedMotion = computed(() =>
+  typeof window !== 'undefined' &&
+  window.matchMedia &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+)
+
+function clearTimers() {
+  while (timers.length) clearTimeout(timers.shift()!)
+}
+
+function startCycle() {
+  clearTimers()
+  isExiting.value = false
+  isFlipped.value = false
+  showRating.value = false
+  highlightedRating.value = null
+
+  if (reducedMotion.value) {
+    isFlipped.value = true
+    showRating.value = true
+    highlightedRating.value = card.value.rating
+    return
+  }
+
+  timers.push(setTimeout(() => { isFlipped.value = true }, 2000))
+  timers.push(setTimeout(() => { showRating.value = true }, 2300))
+  timers.push(setTimeout(() => { highlightedRating.value = card.value.rating }, 3400))
+  timers.push(setTimeout(() => { isExiting.value = true }, 4900))
+  timers.push(setTimeout(() => {
+    currentIndex.value = (currentIndex.value + 1) % cards.length
+    startCycle()
+  }, 5300))
+}
+
+onMounted(startCycle)
+onBeforeUnmount(clearTimers)
+</script>
+
+<template>
+  <div class="flex flex-col overflow-hidden rounded-xl border border-border/60 bg-card/60 shadow-2xl glow-accent-lg lg:h-[420px]">
+    <!-- Window chrome -->
+    <div class="flex items-center gap-2 px-4 py-3 border-b border-border/60 bg-card/80">
+      <span class="h-2.5 w-2.5 rounded-full bg-[#ff5f57]/80"></span>
+      <span class="h-2.5 w-2.5 rounded-full bg-[#febc2e]/80"></span>
+      <span class="h-2.5 w-2.5 rounded-full bg-[#28c840]/80"></span>
+      <span class="ml-3 text-[11px] text-muted-foreground/70">fasolt — Study</span>
+    </div>
+
+    <!-- Body -->
+    <div class="flex-1 px-4 py-4 sm:px-5 sm:py-5">
+      <!-- Context bar -->
+      <div class="mb-3 flex items-center justify-between text-[10px] text-muted-foreground">
+        <div class="flex items-center gap-2">
+          <span class="text-accent uppercase tracking-[0.15em]">Review</span>
+          <span class="text-border">|</span>
+          <span>{{ currentIndex + 1 }} of {{ totalInDeck }}</span>
+        </div>
+        <span class="hidden sm:flex items-center gap-1">
+          <span class="rounded border border-border/60 px-1.5 py-0.5 text-[9px] font-mono">space</span>
+          flip
+        </span>
+      </div>
+
+      <!-- Progress meter -->
+      <div class="mb-5 h-1 w-full overflow-hidden rounded bg-border/60">
+        <div class="h-full bg-accent transition-all duration-500" :style="{ width: progressPct + '%' }"></div>
+      </div>
+
+      <!-- Card -->
+      <div
+        class="relative rounded border border-border/60 bg-background/60 p-5 transition-all duration-300"
+        :class="isExiting ? 'opacity-0 -translate-y-1' : 'opacity-100 translate-y-0'"
+        style="min-height: 140px;"
+      >
+        <div class="text-[10px] uppercase tracking-[0.2em] mb-3 text-accent/70">
+          {{ isFlipped ? 'Answer' : 'Question' }}
+        </div>
+        <div
+          class="text-[13.5px] leading-relaxed transition-colors duration-300"
+          :class="isFlipped ? 'text-muted-foreground' : 'text-foreground'"
+        >
+          {{ card.front }}
+        </div>
+        <div
+          v-if="isFlipped"
+          class="mt-3 text-[13.5px] leading-relaxed text-foreground"
+          style="animation: fade-in 350ms ease-out;"
+        >
+          {{ card.back }}
+        </div>
+      </div>
+
+      <!-- Below card -->
+      <div class="mt-4 transition-opacity duration-300" :class="isExiting ? 'opacity-0' : 'opacity-100'">
+        <div v-if="!showRating" class="text-center text-[11px] text-muted-foreground">
+          Click the card or press
+          <span class="rounded border border-border/60 px-1.5 py-0.5 text-[9px] font-mono">space</span>
+          to reveal the answer
+        </div>
+        <div v-else class="flex flex-wrap justify-center gap-2" style="animation: fade-in 250ms ease-out;">
+          <button
+            v-for="(r, i) in [
+              { label: 'Again', cls: 'border-destructive/50 text-destructive', activeCls: 'bg-destructive/10' },
+              { label: 'Hard', cls: 'border-warning/50 text-warning', activeCls: 'bg-warning/10' },
+              { label: 'Good', cls: 'border-success/50 text-success', activeCls: 'bg-success/10' },
+              { label: 'Easy', cls: 'border-accent/50 text-accent', activeCls: 'bg-accent/10' },
+            ]"
+            :key="r.label"
+            class="flex-1 min-w-[70px] rounded border px-3 py-2 text-[11px] font-medium transition-all"
+            :class="[r.cls, highlightedRating === i ? r.activeCls : 'bg-transparent']"
+            type="button"
+            tabindex="-1"
+          >
+            {{ r.label }}
+            <span class="ml-1 text-[9px] opacity-50">{{ i + 1 }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+</style>

--- a/fasolt.client/src/components/ToolSwitcher.vue
+++ b/fasolt.client/src/components/ToolSwitcher.vue
@@ -1,0 +1,236 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount, computed } from 'vue'
+import { RouterLink } from 'vue-router'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import TerminalDemo from '@/components/TerminalDemo.vue'
+
+type ToolKey = 'chatgpt' | 'claude' | 'other'
+
+const tab = ref<ToolKey>('chatgpt')
+
+const userPrompt = 'Make me flashcards from my LLM basics notes.'
+const cards = [
+  'What does a tokenizer do and why is it needed?',
+  'What is the context window of an LLM?',
+  'How does temperature affect text generation?',
+  'What is the difference between pre-training and fine-tuning?',
+  'Why do LLMs hallucinate?',
+  'What is RLHF and what problem does it solve?',
+  'Prompt engineering vs fine-tuning — when to use which?',
+]
+const studyUrl = 'fasolt.app/decks/a1b2c3'
+
+const phase = ref<'thinking' | 'streaming' | 'done'>('thinking')
+const visibleCards = ref(0)
+const showFooter = ref(false)
+
+const timers: ReturnType<typeof setTimeout>[] = []
+const reducedMotion = computed(() =>
+  typeof window !== 'undefined' &&
+  window.matchMedia &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+)
+
+function clearTimers() {
+  while (timers.length) clearTimeout(timers.shift()!)
+}
+
+function jumpToDone() {
+  clearTimers()
+  visibleCards.value = cards.length
+  showFooter.value = true
+  phase.value = 'done'
+}
+
+function runScript() {
+  clearTimers()
+  visibleCards.value = 0
+  showFooter.value = false
+  phase.value = 'thinking'
+
+  if (reducedMotion.value) {
+    jumpToDone()
+    return
+  }
+
+  const thinkingMs = 700
+  timers.push(setTimeout(() => {
+    phase.value = 'streaming'
+  }, thinkingMs))
+
+  const cardStagger = 180
+  cards.forEach((_, idx) => {
+    timers.push(setTimeout(() => {
+      visibleCards.value = idx + 1
+    }, thinkingMs + 100 + idx * cardStagger))
+  })
+
+  const afterCards = thinkingMs + 100 + cards.length * cardStagger
+  timers.push(setTimeout(() => {
+    showFooter.value = true
+    phase.value = 'done'
+  }, afterCards + 200))
+}
+
+onMounted(runScript)
+onBeforeUnmount(clearTimers)
+watch(tab, runScript)
+</script>
+
+<template>
+  <div>
+    <Tabs v-model="tab" class="w-full">
+      <TabsList class="bg-card/60 border border-border/60 rounded-md p-1 gap-1">
+        <TabsTrigger value="chatgpt" class="text-xs px-3">ChatGPT</TabsTrigger>
+        <TabsTrigger value="claude" class="text-xs px-3">Claude</TabsTrigger>
+        <TabsTrigger value="other" class="text-xs px-3 text-muted-foreground/70 data-[state=active]:text-foreground">Other</TabsTrigger>
+      </TabsList>
+
+      <!-- ChatGPT -->
+      <TabsContent value="chatgpt" class="mt-4">
+        <div
+          class="flex flex-col overflow-hidden rounded-xl border border-border/60 shadow-2xl glow-accent-lg lg:h-[420px]"
+          style="background: #ffffff; font-family: 'Söhne', 'Inter', system-ui, -apple-system, sans-serif;"
+        >
+          <!-- Window chrome -->
+          <div class="flex items-center gap-2 px-4 py-3 border-b" style="border-color: #ececec; background: #f9f9f9;">
+            <span class="h-2.5 w-2.5 rounded-full" style="background: #ff5f57"></span>
+            <span class="h-2.5 w-2.5 rounded-full" style="background: #febc2e"></span>
+            <span class="h-2.5 w-2.5 rounded-full" style="background: #28c840"></span>
+            <span class="ml-3 text-[11px]" style="color: #8e8ea0">ChatGPT</span>
+          </div>
+
+          <!-- Body -->
+          <div class="flex flex-col px-5 py-5 sm:px-6 sm:py-6 text-[13px] sm:text-[14px] flex-1" style="color: #1f2328;">
+            <!-- User message -->
+            <div class="flex justify-end mb-4">
+              <div
+                class="rounded-3xl px-4 py-2 max-w-[85%]"
+                style="background: #f4f4f4; color: #1f2328;"
+              >
+                {{ userPrompt }}
+              </div>
+            </div>
+
+            <!-- Assistant response -->
+            <div class="flex gap-3">
+              <div
+                class="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-white text-[10px] font-bold mt-0.5"
+                style="background: #10a37f;"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+                </svg>
+              </div>
+              <div class="flex-1 leading-relaxed">
+                <div v-if="phase === 'thinking'" class="flex gap-1 items-center pt-1.5" style="color: #8e8ea0">
+                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #8e8ea0;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #8e8ea0; animation-delay: 0.15s;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #8e8ea0; animation-delay: 0.3s;"></span>
+                </div>
+                <template v-else>
+                  <p class="mb-3">I'll create flashcards from your notes on LLM basics:</p>
+                  <ul class="space-y-1.5 mb-3">
+                    <li
+                      v-for="(c, i) in cards"
+                      :key="i"
+                      v-show="i < visibleCards"
+                      class="gap-2 transition-opacity duration-300"
+                      :class="i < 2 ? 'flex' : (i < 4 ? 'hidden sm:flex' : 'hidden')"
+                      :style="{ opacity: i < visibleCards ? 1 : 0 }"
+                    >
+                      <span style="color: #10a37f;">✓</span>
+                      <span>{{ c }}</span>
+                    </li>
+                  </ul>
+                  <p v-if="showFooter" class="text-[12px] sm:text-[13px]" style="color: #6b6c7b;">
+                    7 cards created in your “LLM Basics” deck —
+                    <a href="#" class="underline" style="color: #10a37f;">{{ studyUrl }}</a>
+                  </p>
+                </template>
+              </div>
+            </div>
+          </div>
+        </div>
+      </TabsContent>
+
+      <!-- Claude -->
+      <TabsContent value="claude" class="mt-4">
+        <div
+          class="flex flex-col overflow-hidden rounded-xl border border-border/60 shadow-2xl glow-accent-lg lg:h-[420px]"
+          style="background: #faf9f5; font-family: 'Styrene B', 'Inter', system-ui, -apple-system, sans-serif;"
+        >
+          <!-- Window chrome -->
+          <div class="flex items-center gap-2 px-4 py-3 border-b" style="border-color: #e8e6dc; background: #f5f3eb;">
+            <span class="h-2.5 w-2.5 rounded-full" style="background: #ff5f57"></span>
+            <span class="h-2.5 w-2.5 rounded-full" style="background: #febc2e"></span>
+            <span class="h-2.5 w-2.5 rounded-full" style="background: #28c840"></span>
+            <span class="ml-3 text-[11px]" style="color: #91918b">Claude</span>
+          </div>
+
+          <!-- Body -->
+          <div class="flex flex-col px-5 py-5 sm:px-6 sm:py-6 text-[13.5px] sm:text-[14.5px] flex-1" style="color: #2d2c28;">
+            <!-- User message -->
+            <div class="flex justify-end mb-4">
+              <div
+                class="rounded-2xl px-4 py-2.5 max-w-[85%]"
+                style="background: #efece1; color: #2d2c28;"
+              >
+                {{ userPrompt }}
+              </div>
+            </div>
+
+            <!-- Assistant response -->
+            <div class="flex gap-3">
+              <div
+                class="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center text-white text-[12px] font-bold mt-0.5"
+                style="background: #d97757; font-family: serif;"
+              >
+                C
+              </div>
+              <div class="flex-1 leading-relaxed">
+                <div v-if="phase === 'thinking'" class="flex gap-1 items-center pt-1.5" style="color: #91918b">
+                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #d97757;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #d97757; animation-delay: 0.15s;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #d97757; animation-delay: 0.3s;"></span>
+                </div>
+                <template v-else>
+                  <p class="mb-3">Here are flashcards from your LLM basics notes:</p>
+                  <ul class="space-y-1.5 mb-3">
+                    <li
+                      v-for="(c, i) in cards"
+                      :key="i"
+                      v-show="i < visibleCards"
+                      class="gap-2 transition-opacity duration-300"
+                      :class="i < 2 ? 'flex' : (i < 4 ? 'hidden sm:flex' : 'hidden')"
+                      :style="{ opacity: i < visibleCards ? 1 : 0 }"
+                    >
+                      <span style="color: #d97757;">✓</span>
+                      <span>{{ c }}</span>
+                    </li>
+                  </ul>
+                  <p v-if="showFooter" class="text-[12px] sm:text-[13px]" style="color: #6b6a62;">
+                    Created 7 cards in your “LLM Basics” deck —
+                    <a href="#" class="underline" style="color: #d97757;">{{ studyUrl }}</a>
+                  </p>
+                </template>
+              </div>
+            </div>
+          </div>
+        </div>
+      </TabsContent>
+
+      <!-- Other / Developers -->
+      <TabsContent value="other" class="mt-4">
+        <TerminalDemo />
+        <p class="mt-3 text-xs text-muted-foreground">
+          Works with Claude Code, Cursor, and any MCP-compatible client.
+        </p>
+      </TabsContent>
+    </Tabs>
+
+    <p class="mt-4 text-xs text-muted-foreground">
+      <RouterLink to="/mcp-setup" class="text-accent hover:underline">How to connect →</RouterLink>
+    </p>
+  </div>
+</template>

--- a/fasolt.client/src/router/index.ts
+++ b/fasolt.client/src/router/index.ts
@@ -22,7 +22,7 @@ const router = createRouter({
       path: '/',
       name: 'landing',
       component: () => import('@/views/LandingView.vue'),
-      meta: { public: true, authRedirect: true, landing: true, title: 'MCP-first spaced repetition for markdown notes' },
+      meta: { public: true, authRedirect: true, landing: true, title: 'Spaced repetition, powered by the AI you already use' },
     },
     {
       path: '/algorithm',

--- a/fasolt.client/src/views/LandingView.vue
+++ b/fasolt.client/src/views/LandingView.vue
@@ -3,8 +3,10 @@ import { RouterLink } from 'vue-router'
 import { Button } from '@/components/ui/button'
 import { Moon, Sun, Bot, Layers, FileText, Brain, BarChart3, Image, Search, Server } from 'lucide-vue-next'
 import { useDarkMode } from '@/composables/useDarkMode'
-import TerminalDemo from '@/components/TerminalDemo.vue'
+import ToolSwitcher from '@/components/ToolSwitcher.vue'
+import FasoltStudyPreview from '@/components/FasoltStudyPreview.vue'
 import AppFooter from '@/components/AppFooter.vue'
+import { ArrowRight, ArrowDown } from 'lucide-vue-next'
 
 const { isDark, toggle } = useDarkMode()
 </script>
@@ -38,18 +40,18 @@ const { isDark, toggle } = useDarkMode()
     </nav>
 
     <!-- Hero -->
-    <section class="relative mx-auto max-w-5xl px-6 pt-20 pb-12 sm:pt-32 sm:pb-16">
+    <section class="relative mx-auto max-w-5xl px-6 pt-6 pb-12 sm:pt-10 sm:pb-16">
       <div class="max-w-2xl">
         <p class="mb-4 text-xs uppercase tracking-[0.2em] text-accent">spaced repetition</p>
         <h1 class="text-2xl sm:text-4xl font-bold tracking-tight leading-tight mb-5">
-          <span class="text-accent text-glow">MCP-first</span> spaced repetition<br class="hidden sm:block" />
-          powered by your AI.
+          Spaced repetition,<br class="hidden sm:block" />
+          powered by the <span class="text-accent text-glow">AI you already use</span>.
         </h1>
         <p class="text-sm text-muted-foreground mb-8 max-w-md leading-relaxed">
-          Your AI agent creates flashcards from your notes, a topic, or anything you want to learn.
+          Ask ChatGPT or Claude to make flashcards from your notes, a topic, or anything you want to learn.
           Study on the web or the iOS app. Free.
         </p>
-        <div class="flex flex-wrap gap-3">
+        <div class="flex flex-wrap items-center gap-3">
           <a href="/register">
             <Button class="glow-accent">Get started</Button>
           </a>
@@ -57,13 +59,32 @@ const { isDark, toggle } = useDarkMode()
             <Button variant="outline">Log in</Button>
           </a>
         </div>
+        <p class="mt-4 text-xs text-muted-foreground/80">
+          Works with ChatGPT, Claude, and any MCP-compatible AI.
+        </p>
       </div>
     </section>
 
-    <!-- Terminal demo -->
-    <section class="relative mx-auto max-w-5xl px-6 pb-20">
-      <div class="max-w-2xl">
-        <TerminalDemo />
+    <!-- Tool switcher demo + study preview -->
+    <section class="relative mx-auto max-w-6xl px-6 pb-20">
+      <div class="grid gap-4 lg:grid-cols-[1fr_auto_1fr] lg:gap-4">
+        <div class="flex min-w-0 flex-col">
+          <p class="mb-3 text-[10px] uppercase tracking-[0.2em] text-accent/70">1 — Ask your AI</p>
+          <ToolSwitcher />
+        </div>
+        <div class="hidden lg:flex items-center justify-center text-muted-foreground/60">
+          <ArrowRight :size="24" />
+        </div>
+        <div class="flex justify-center lg:hidden text-muted-foreground/60 -my-1">
+          <ArrowDown :size="18" />
+        </div>
+        <div class="flex min-w-0 flex-col">
+          <p class="mb-3 text-[10px] uppercase tracking-[0.2em] text-accent/70">2 — Study in fasolt</p>
+          <FasoltStudyPreview />
+          <p class="mt-3 text-xs text-muted-foreground">
+            Cards are scheduled with FSRS — the more you remember, the longer the gaps.
+          </p>
+        </div>
       </div>
     </section>
 
@@ -74,9 +95,9 @@ const { isDark, toggle } = useDarkMode()
         <div class="grid gap-10 sm:grid-cols-3">
           <div>
             <span class="text-xs text-accent/60 mb-2 block">01</span>
-            <h3 class="text-sm font-semibold mb-2">Connect your AI agent</h3>
+            <h3 class="text-sm font-semibold mb-2">Connect ChatGPT or Claude</h3>
             <p class="text-xs text-muted-foreground leading-relaxed">
-              Add the fasolt MCP server to Claude, ChatGPT, or any MCP-compatible agent.
+              Add fasolt to ChatGPT, Claude, or any AI tool that supports connectors.
             </p>
           </div>
           <div>
@@ -103,8 +124,8 @@ const { isDark, toggle } = useDarkMode()
       <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <div class="rounded border border-border/60 bg-card/50 p-4">
           <Bot :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">MCP tools</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">AI agents create and manage cards via MCP.</p>
+          <h3 class="text-sm font-semibold mb-1">Bring your own AI</h3>
+          <p class="text-xs text-muted-foreground leading-relaxed">Use ChatGPT, Claude, or any MCP-compatible agent to create and manage cards.</p>
         </div>
         <div class="rounded border border-border/60 bg-card/50 p-4">
           <Brain :size="16" class="text-accent mb-2" />


### PR DESCRIPTION
## Summary
- Hero, "How it works" step 1, and the primary feature card now lead with **ChatGPT / Claude** instead of **MCP**. "MCP-first" is gone from the H1; MCP is still mentioned, but as a supporting detail.
- Replaces the lone dark terminal demo with a side-by-side story: a chat-bubble recreation of asking the AI for flashcards (with **ChatGPT / Claude / Other** tabs — the terminal lives under "Other"), arrow `→`, then a live preview of the fasolt study UI looping through 3 cards with rating highlights.
- Mobile shrinks the chat to ~2 cards and stacks the panels with a `↓` between them. Both panels match heights at `lg`.
- Page title updated to drop "MCP-first."

## Why
A non-technical user reported bouncing on the live page because (a) they didn't know what MCP was and (b) the terminal demo signalled "this is for developers." The chat + study panel pairing answers two unspoken questions in one glance: "what does this look like for me?" and "how do I actually study the cards?" — without requiring any prior knowledge of MCP.

## Test plan
- [ ] Hero reads cleanly on desktop and mobile; no MCP jargon above the fold
- [ ] ChatGPT and Claude tabs render the chat-bubble UIs and animate
- [ ] "Other" tab still shows the original terminal demo
- [ ] FasoltStudyPreview loops through the 3 cards (Tokenizer / Context window / Temperature), each with its own rating highlight
- [ ] Mobile shows 2 cards in the chat + a compact study panel
- [ ] `prefers-reduced-motion` jumps to the final state instead of animating
- [ ] "How to connect →" link points to `/mcp-setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)