### PR TITLE
Document Markdown and SVG rules in MCP create_cards / update_cards schemas

### DIFF
--- a/fasolt.Server/Application/Dtos/BulkCardDtos.cs
+++ b/fasolt.Server/Application/Dtos/BulkCardDtos.cs
@@ -1,6 +1,18 @@
+using System.ComponentModel;
+
 namespace Fasolt.Server.Application.Dtos;
 
 public record BulkCreateCardsRequest(string? SourceFile, string? DeckId, List<BulkCardItem> Cards);
-public record BulkCardItem(string Front, string Back, string? SourceFile = null, string? SourceHeading = null, string? FrontSvg = null, string? BackSvg = null);
+public record BulkCardItem(
+    [property: Description("Front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX/math (e.g. $...$) is NOT rendered. Example: \"What is the **capital** of France?\"")]
+    string Front,
+    [property: Description("Back of the card (answer/explanation). Same Markdown features as `front`. Use line breaks and lists for readability. HTML and LaTeX are NOT rendered. Example: \"**Empiricism**: all knowledge stems from sense experience. *Tabula rasa* (Locke). Key figures: Locke, Berkeley, Hume.\"")]
+    string Back,
+    string? SourceFile = null,
+    string? SourceHeading = null,
+    [property: Description("Optional inline SVG for the front. Must start with `<svg`. Sanitized server-side: <style>, <script>, <foreignObject>, all event handlers (on*), the `style` attribute, `font-weight`, `font-style`, and external `href` values are stripped. For emphasis use `fill`, `stroke`, or `font-size` — bold/italic via CSS will not survive. Allowed tags include: svg, g, defs, path, circle, rect, line, polyline, polygon, ellipse, text, tspan, use, marker, symbol, linearGradient, radialGradient, stop, filter, feGaussianBlur, feOffset, feMerge, feMergeNode, clipPath, mask, pattern, title, desc. Use a landscape viewBox like '0 0 400 250'. Max ~1MB.")]
+    string? FrontSvg = null,
+    [property: Description("Optional inline SVG for the back. Same sanitization rules as `frontSvg`.")]
+    string? BackSvg = null);
 public record BulkCreateCardsResponse(List<CardDto> Created, List<SkippedCardDto> Skipped);
 public record SkippedCardDto(string Front, string Reason);

--- a/fasolt.Server/Application/Dtos/CardDtos.cs
+++ b/fasolt.Server/Application/Dtos/CardDtos.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Fasolt.Server.Application.Dtos;
 
 public record CreateCardRequest(string? SourceFile, string? SourceHeading, string Front, string Back, string? FrontSvg = null, string? BackSvg = null, string? DeckId = null);
@@ -40,14 +42,21 @@ public record UpdateCardResult(UpdateCardStatus Status, CardDto? Card = null)
 }
 
 public record BulkUpdateCardItem(
+    [property: Description("Lookup key: card ID. Either provide this OR (sourceFile + front).")]
     string? CardId = null,
+    [property: Description("Lookup key part 1: source file. Combine with `front` for case-insensitive natural-key lookup when `cardId` is unknown.")]
     string? SourceFile = null,
+    [property: Description("Lookup key part 2: existing front text (case-insensitive). Combine with `sourceFile`.")]
     string? Front = null,
+    [property: Description("New front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX/math (e.g. $...$) is NOT rendered. Example: \"What is the **capital** of France?\"")]
     string? NewFront = null,
+    [property: Description("New back of the card (answer/explanation). Same Markdown features as `newFront`. HTML and LaTeX are NOT rendered. Example: \"**Empiricism**: all knowledge stems from sense experience. *Tabula rasa* (Locke). Key figures: Locke, Berkeley, Hume.\"")]
     string? NewBack = null,
     string? NewSourceFile = null,
     string? NewSourceHeading = null,
+    [property: Description("New inline SVG for the front. Must start with `<svg`. Sanitized server-side: <style>, <script>, <foreignObject>, all event handlers (on*), the `style` attribute, `font-weight`, `font-style`, and external `href` values are stripped. For emphasis use `fill`, `stroke`, or `font-size` — bold/italic via CSS will not survive. Allowed tags include: svg, g, defs, path, circle, rect, line, polyline, polygon, ellipse, text, tspan, use, marker, symbol, linearGradient, radialGradient, stop, filter, feGaussianBlur, feOffset, feMerge, feMergeNode, clipPath, mask, pattern, title, desc. Use a landscape viewBox like '0 0 400 250'. Max ~1MB.")]
     string? NewFrontSvg = null,
+    [property: Description("New inline SVG for the back. Same sanitization rules as `newFrontSvg`.")]
     string? NewBackSvg = null);
 
 public record BulkUpdateCardResult(string? CardId, string? SourceFile, string? Front, UpdateCardStatus Status, CardDto? Card = null);


### PR DESCRIPTION
## Summary

LLM clients calling \`create_cards\` and \`update_cards\` had no guidance on:
- which Markdown features the \`front\` / \`back\` text actually renders to (and which it does not — e.g. HTML and LaTeX);
- which parts of an SVG would be silently stripped by the server-side sanitizer (notably \`<style>\`, \`font-weight\`, \`font-style\`, on* handlers, and the \`style\` attribute).

This PR adds \`[property: Description]\` attributes on the positional record parameters of \`BulkCardItem\` and \`BulkUpdateCardItem\` so the per-field guidance appears in the JSON Schema returned by \`tools/list\`. Examples are embedded inline in the descriptions (the .NET MCP SDK doesn't surface JSONSchema \`examples\` automatically; LLMs reliably follow inline examples).

### What the new descriptions cover

- **Markdown fields** — name the supported features (headings, **bold**, *italic*, ~~strikethrough~~, \`code\`, fenced blocks, lists, blockquotes, tables, links, auto-linked URLs), spell out that soft newlines are preserved, that HTML is escaped (not rendered), and that LaTeX/math is **not** rendered. Each field carries one concrete example.
- **SVG fields** — spell out the exact sanitizer behavior verified in \`SvgSanitizer.cs\`: \`<style>\`, \`<script>\`, \`<foreignObject>\`, \`on*\` event handlers, the \`style\` attribute, \`font-weight\`, \`font-style\`, and external \`href\` values are stripped. Emphasis must come from \`fill\` / \`stroke\` / \`font-size\`. The allowed-tag list is named. Landscape viewBox \`0 0 400 250\` and ~1MB max are restated.

## Test plan

- [x] \`dotnet build fasolt.Server\` clean.
- [x] \`dotnet test fasolt.Tests\` — 268/268 passing (positional construction unaffected since attributes attach to properties only).
- [x] Verified via reflection that \`DescriptionAttribute\` is attached to each generated property (which is what \`JsonSchemaExporter\` reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)