### PR TITLE
Render LaTeX math in card front and back via KaTeX

### DIFF
--- a/fasolt.Server/Api/Endpoints/DemoDeckEndpoints.cs
+++ b/fasolt.Server/Api/Endpoints/DemoDeckEndpoints.cs
@@ -17,7 +17,7 @@ public static class DemoDeckEndpoints
         new("What can you do with decks and cards?",
             "**Decks** organize cards into focused study groups. You can **suspend** a deck to temporarily hide all its cards from review, or **suspend individual cards** you don't want to see right now. Suspended items keep their progress — unsuspend them anytime to pick up where you left off."),
         new("What formatting do cards support?",
-            "Cards fully support **markdown** — bold, italic, lists, headings, links, and more. You can also include fenced code blocks with syntax highlighting:\n\n```python\ndef hello(name: str) -> str:\n    return f\"Hello, {name}!\"\n```\n\nYour AI agent writes the markdown automatically when creating cards from your notes."),
+            "Cards fully support **markdown** — bold, italic, lists, headings, links, and more. You can also include fenced code blocks with syntax highlighting:\n\n```python\ndef hello(name: str) -> str:\n    return f\"Hello, {name}!\"\n```\n\n**LaTeX math** is rendered with KaTeX — inline like \\(e^{i\\pi} + 1 = 0\\) and block like:\n\n$$\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$$\n\nChemistry via mhchem (\\(\\ce{2H2 + O2 -> 2H2O}\\)) and physics shortcuts (\\(\\pdv{\\psi}{t}\\)) are preconfigured."),
     ];
 
     public static void MapDemoDeckEndpoints(this WebApplication app)

--- a/fasolt.Server/Api/McpTools/CardTools.cs
+++ b/fasolt.Server/Api/McpTools/CardTools.cs
@@ -52,7 +52,7 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
         return JsonSerializer.Serialize(result, McpJson.Options);
     }
 
-    [McpServerTool, Description("Create one or more flashcards, optionally linked to a source file and/or deck. Each card can include SVG images for front and/or back (use a landscape viewBox like '0 0 400 250' for best display). Returns created cards, any skipped duplicates, and a deckUrl deep link if a deck was used.")]
+    [McpServerTool, Description("Create one or more flashcards, optionally linked to a source file and/or deck. Card text is Markdown with KaTeX math support — emit \\(...\\) / $...$ for inline math and \\[...\\] / $$...$$ for block math (mhchem chemistry and \\dv/\\pdv/\\abs/\\norm physics shortcuts are preconfigured). Each card can also include SVG images for front and/or back (use a landscape viewBox like '0 0 400 250' for best display). Returns created cards, any skipped duplicates, and a deckUrl deep link if a deck was used.")]
     public async Task<string> CreateCards(
         [Description("Array of cards to create. Each card needs 'front' and 'back' text, plus optional 'sourceFile' and 'sourceHeading'.")] List<BulkCardItem> cards,
         [Description("Default source file name for all cards (individual cards can override)")] string? sourceFile = null,
@@ -98,7 +98,7 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
         return JsonSerializer.Serialize(new { deleted = count > 0, deletedCount = count }, McpJson.Options);
     }
 
-    [McpServerTool, Description("Update one or more existing cards' text or source metadata. Preserves all review/SRS history. Each card can be looked up by cardId, or by sourceFile + front (case-insensitive natural key).")]
+    [McpServerTool, Description("Update one or more existing cards' text or source metadata. Preserves all review/SRS history. Each card can be looked up by cardId, or by sourceFile + front (case-insensitive natural key). Card text fields accept the same Markdown + KaTeX math (mhchem, physics shortcuts) as create_cards.")]
     public async Task<string> UpdateCards(
         [Description("Array of card updates. Each needs a lookup key (cardId, or sourceFile + front) and at least one field to update (newFront, newBack, newSourceFile, newSourceHeading, newFrontSvg, newBackSvg).")] List<BulkUpdateCardItem> cards)
     {

--- a/fasolt.Server/Application/Dtos/BulkCardDtos.cs
+++ b/fasolt.Server/Application/Dtos/BulkCardDtos.cs
@@ -1,6 +1,18 @@
+using System.ComponentModel;
+
 namespace Fasolt.Server.Application.Dtos;
 
 public record BulkCreateCardsRequest(string? SourceFile, string? DeckId, List<BulkCardItem> Cards);
-public record BulkCardItem(string Front, string Back, string? SourceFile = null, string? SourceHeading = null, string? FrontSvg = null, string? BackSvg = null);
+public record BulkCardItem(
+    [property: Description("Front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX/math (e.g. $...$) is NOT rendered. Example: \"What is the **capital** of France?\"")]
+    string Front,
+    [property: Description("Back of the card (answer/explanation). Same Markdown features as `front`. Use line breaks and lists for readability. HTML and LaTeX are NOT rendered. Example: \"**Empiricism**: all knowledge stems from sense experience. *Tabula rasa* (Locke). Key figures: Locke, Berkeley, Hume.\"")]
+    string Back,
+    string? SourceFile = null,
+    string? SourceHeading = null,
+    [property: Description("Optional inline SVG for the front. Must start with `<svg`. Sanitized server-side: <style>, <script>, <foreignObject>, all event handlers (on*), the `style` attribute, `font-weight`, `font-style`, and external `href` values are stripped. For emphasis use `fill`, `stroke`, or `font-size` — bold/italic via CSS will not survive. Allowed tags include: svg, g, defs, path, circle, rect, line, polyline, polygon, ellipse, text, tspan, use, marker, symbol, linearGradient, radialGradient, stop, filter, feGaussianBlur, feOffset, feMerge, feMergeNode, clipPath, mask, pattern, title, desc. Use a landscape viewBox like '0 0 400 250'. Max ~1MB.")]
+    string? FrontSvg = null,
+    [property: Description("Optional inline SVG for the back. Same sanitization rules as `frontSvg`.")]
+    string? BackSvg = null);
 public record BulkCreateCardsResponse(List<CardDto> Created, List<SkippedCardDto> Skipped);
 public record SkippedCardDto(string Front, string Reason);

--- a/fasolt.Server/Application/Dtos/BulkCardDtos.cs
+++ b/fasolt.Server/Application/Dtos/BulkCardDtos.cs
@@ -4,9 +4,9 @@ namespace Fasolt.Server.Application.Dtos;
 
 public record BulkCreateCardsRequest(string? SourceFile, string? DeckId, List<BulkCardItem> Cards);
 public record BulkCardItem(
-    [property: Description("Front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX/math (e.g. $...$) is NOT rendered. Example: \"What is the **capital** of France?\"")]
+    [property: Description("Front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX math IS rendered via KaTeX — use \\(...\\) or $...$ for inline and \\[...\\] or $$...$$ for block math; chemistry via mhchem (\\ce{H2O}, \\pu{1.21 GW}) and the physics-package shortcuts \\dv, \\pdv, \\abs, \\norm are preconfigured. Document-level LaTeX (\\documentclass, \\input, \\includegraphics, \\href) is NOT supported. Example: \"What is the derivative of \\(\\sin(x)\\)?\"")]
     string Front,
-    [property: Description("Back of the card (answer/explanation). Same Markdown features as `front`. Use line breaks and lists for readability. HTML and LaTeX are NOT rendered. Example: \"**Empiricism**: all knowledge stems from sense experience. *Tabula rasa* (Locke). Key figures: Locke, Berkeley, Hume.\"")]
+    [property: Description("Back of the card (answer/explanation). Same Markdown + KaTeX math features as `front`. Use line breaks and lists for readability. Example: \"\\(\\cos(x)\\). In general, \\(\\dv{}{x}\\sin(x) = \\cos(x)\\).\"")]
     string Back,
     string? SourceFile = null,
     string? SourceHeading = null,

--- a/fasolt.Server/Application/Dtos/CardDtos.cs
+++ b/fasolt.Server/Application/Dtos/CardDtos.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Fasolt.Server.Application.Dtos;
 
 public record CreateCardRequest(string? SourceFile, string? SourceHeading, string Front, string Back, string? FrontSvg = null, string? BackSvg = null, string? DeckId = null);
@@ -40,14 +42,21 @@ public record UpdateCardResult(UpdateCardStatus Status, CardDto? Card = null)
 }
 
 public record BulkUpdateCardItem(
+    [property: Description("Lookup key: card ID. Either provide this OR (sourceFile + front).")]
     string? CardId = null,
+    [property: Description("Lookup key part 1: source file. Combine with `front` for case-insensitive natural-key lookup when `cardId` is unknown.")]
     string? SourceFile = null,
+    [property: Description("Lookup key part 2: existing front text (case-insensitive). Combine with `sourceFile`.")]
     string? Front = null,
+    [property: Description("New front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX/math (e.g. $...$) is NOT rendered. Example: \"What is the **capital** of France?\"")]
     string? NewFront = null,
+    [property: Description("New back of the card (answer/explanation). Same Markdown features as `newFront`. HTML and LaTeX are NOT rendered. Example: \"**Empiricism**: all knowledge stems from sense experience. *Tabula rasa* (Locke). Key figures: Locke, Berkeley, Hume.\"")]
     string? NewBack = null,
     string? NewSourceFile = null,
     string? NewSourceHeading = null,
+    [property: Description("New inline SVG for the front. Must start with `<svg`. Sanitized server-side: <style>, <script>, <foreignObject>, all event handlers (on*), the `style` attribute, `font-weight`, `font-style`, and external `href` values are stripped. For emphasis use `fill`, `stroke`, or `font-size` — bold/italic via CSS will not survive. Allowed tags include: svg, g, defs, path, circle, rect, line, polyline, polygon, ellipse, text, tspan, use, marker, symbol, linearGradient, radialGradient, stop, filter, feGaussianBlur, feOffset, feMerge, feMergeNode, clipPath, mask, pattern, title, desc. Use a landscape viewBox like '0 0 400 250'. Max ~1MB.")]
     string? NewFrontSvg = null,
+    [property: Description("New inline SVG for the back. Same sanitization rules as `newFrontSvg`.")]
     string? NewBackSvg = null);
 
 public record BulkUpdateCardResult(string? CardId, string? SourceFile, string? Front, UpdateCardStatus Status, CardDto? Card = null);

--- a/fasolt.Server/Application/Dtos/CardDtos.cs
+++ b/fasolt.Server/Application/Dtos/CardDtos.cs
@@ -48,9 +48,9 @@ public record BulkUpdateCardItem(
     string? SourceFile = null,
     [property: Description("Lookup key part 2: existing front text (case-insensitive). Combine with `sourceFile`.")]
     string? Front = null,
-    [property: Description("New front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX/math (e.g. $...$) is NOT rendered. Example: \"What is the **capital** of France?\"")]
+    [property: Description("New front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX math IS rendered via KaTeX — use \\(...\\) or $...$ for inline and \\[...\\] or $$...$$ for block math; chemistry via mhchem (\\ce{H2O}, \\pu{1.21 GW}) and the physics-package shortcuts \\dv, \\pdv, \\abs, \\norm are preconfigured. Document-level LaTeX (\\documentclass, \\input, \\includegraphics, \\href) is NOT supported. Example: \"What is the derivative of \\(\\sin(x)\\)?\"")]
     string? NewFront = null,
-    [property: Description("New back of the card (answer/explanation). Same Markdown features as `newFront`. HTML and LaTeX are NOT rendered. Example: \"**Empiricism**: all knowledge stems from sense experience. *Tabula rasa* (Locke). Key figures: Locke, Berkeley, Hume.\"")]
+    [property: Description("New back of the card (answer/explanation). Same Markdown + KaTeX math features as `newFront`. Example: \"\\(\\cos(x)\\). In general, \\(\\dv{}{x}\\sin(x) = \\cos(x)\\).\"")]
     string? NewBack = null,
     string? NewSourceFile = null,
     string? NewSourceHeading = null,

--- a/fasolt.Server/Infrastructure/Data/DevSeedData.cs
+++ b/fasolt.Server/Infrastructure/Data/DevSeedData.cs
@@ -482,6 +482,135 @@ public static class DevSeedData
             new DeckCard { DeckId = markdownDeck.Id, CardId = mdMixed.Id }
         );
 
+        // === Admin Deck — LaTeX Math Tests ===
+        var latexDeck = new Deck
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Name = "LaTeX Math Tests",
+            Description = "Cards exercising KaTeX inline/block math, mhchem, and physics macros",
+            CreatedAt = now,
+        };
+        db.Decks.Add(latexDeck);
+
+        var latexInline = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Front = "What is the derivative of \\(\\sin(x)\\)?",
+            Back = "\\(\\cos(x)\\). In general, \\(\\dv{}{x}\\sin(x) = \\cos(x)\\).",
+            SourceFile = "calculus-notes.md",
+            SourceHeading = "Derivatives",
+            State = "new",
+            CreatedAt = now,
+        };
+
+        var latexEulerDollar = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Front = "State Euler's identity using $...$ delimiters.",
+            Back = "$e^{i\\pi} + 1 = 0$\n\nCombines the five most important constants of mathematics: $e$, $i$, $\\pi$, $1$, and $0$.",
+            SourceFile = "calculus-notes.md",
+            SourceHeading = "Identities",
+            State = "new",
+            CreatedAt = now,
+        };
+
+        var latexGaussian = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Front = "What is the value of the Gaussian integral?",
+            Back = "$$\\int_{-\\infty}^{\\infty} e^{-x^{2}}\\,dx = \\sqrt{\\pi}$$",
+            SourceFile = "calculus-notes.md",
+            SourceHeading = "Integrals",
+            State = "new",
+            CreatedAt = now,
+        };
+
+        var latexMatrix = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Front = "Write the 2×2 identity matrix.",
+            Back = "\\[ I_{2} = \\begin{pmatrix} 1 & 0 \\\\ 0 & 1 \\end{pmatrix} \\]",
+            SourceFile = "linear-algebra.md",
+            SourceHeading = "Matrices",
+            State = "new",
+            CreatedAt = now,
+        };
+
+        var latexChem = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Front = "Balance the combustion of hydrogen.",
+            Back = "$$\\ce{2H2 + O2 -> 2H2O}$$\n\nReleases about \\(\\pu{286 kJ/mol}\\) — the reverse reaction is electrolysis.",
+            SourceFile = "chemistry-notes.md",
+            SourceHeading = "Combustion",
+            State = "new",
+            CreatedAt = now,
+        };
+
+        var latexPhysics = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Front = "Write Schrödinger's time-dependent equation using the `\\pdv` shortcut.",
+            Back = "\\[ i\\hbar\\,\\pdv{\\psi}{t} = \\hat H\\,\\psi \\]\n\nThe magnitude of the wave function is \\(\\abs{\\psi}^{2}\\); a normalized state has \\(\\norm{\\psi} = 1\\).",
+            SourceFile = "physics-notes.md",
+            SourceHeading = "Quantum",
+            State = "new",
+            CreatedAt = now,
+        };
+
+        var latexLogic = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Front = "Express \"there exists no x in the empty set\" symbolically.",
+            Back = "\\( \\nexists\\, x \\in \\emptyset \\). Equivalently, \\( \\forall x\\, (x \\notin \\emptyset) \\).",
+            SourceFile = "logic-notes.md",
+            SourceHeading = "Quantifiers",
+            State = "new",
+            CreatedAt = now,
+        };
+
+        var latexMixed = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = adminUser.Id,
+            Front = "## Mixing markdown and math\n\nWhat is the **quadratic formula**?",
+            Back = "For \\( ax^{2} + bx + c = 0 \\) with \\( a \\ne 0 \\):\n\n$$ x = \\frac{-b \\pm \\sqrt{b^{2} - 4ac}}{2a} $$\n\n- The discriminant is \\( \\Delta = b^{2} - 4ac \\).\n- Two real roots when \\( \\Delta > 0 \\).\n- One repeated root when \\( \\Delta = 0 \\).\n- Two complex conjugate roots when \\( \\Delta < 0 \\).",
+            SourceFile = "algebra-notes.md",
+            SourceHeading = "Quadratics",
+            State = "new",
+            CreatedAt = now,
+        };
+
+        db.Cards.AddRange(latexInline, latexEulerDollar, latexGaussian, latexMatrix,
+            latexChem, latexPhysics, latexLogic, latexMixed);
+        db.DeckCards.AddRange(
+            new DeckCard { DeckId = latexDeck.Id, CardId = latexInline.Id },
+            new DeckCard { DeckId = latexDeck.Id, CardId = latexEulerDollar.Id },
+            new DeckCard { DeckId = latexDeck.Id, CardId = latexGaussian.Id },
+            new DeckCard { DeckId = latexDeck.Id, CardId = latexMatrix.Id },
+            new DeckCard { DeckId = latexDeck.Id, CardId = latexChem.Id },
+            new DeckCard { DeckId = latexDeck.Id, CardId = latexPhysics.Id },
+            new DeckCard { DeckId = latexDeck.Id, CardId = latexLogic.Id },
+            new DeckCard { DeckId = latexDeck.Id, CardId = latexMixed.Id }
+        );
+
         // === Regular User Data ===
         var mathDeck = new Deck
         {

--- a/fasolt.client/package-lock.json
+++ b/fasolt.client/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.3",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
+        "@types/katex": "^0.16.8",
         "@vueuse/core": "^14.2.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.3",
+        "katex": "^0.16.45",
         "lucide-vue-next": "^0.577.0",
         "markdown-it": "^14.1.1",
         "pinia": "^3.0.4",
@@ -757,6 +759,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
@@ -2114,6 +2122,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/lightningcss": {

--- a/fasolt.client/package.json
+++ b/fasolt.client/package.json
@@ -16,10 +16,12 @@
   },
   "dependencies": {
     "@tanstack/vue-table": "^8.21.3",
+    "@types/katex": "^0.16.8",
     "@vueuse/core": "^14.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.3",
+    "katex": "^0.16.45",
     "lucide-vue-next": "^0.577.0",
     "markdown-it": "^14.1.1",
     "pinia": "^3.0.4",

--- a/fasolt.client/src/__tests__/composables/useMarkdown.test.ts
+++ b/fasolt.client/src/__tests__/composables/useMarkdown.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { useMarkdown } from '@/composables/useMarkdown'
+
+const { render } = useMarkdown()
+
+describe('useMarkdown — markdown', () => {
+  it('renders plain markdown', () => {
+    expect(render('**bold**')).toContain('<strong>bold</strong>')
+  })
+
+  it('does not interpret math delimiters when no math is present', () => {
+    const html = render('a regular paragraph')
+    expect(html).not.toContain('katex')
+  })
+})
+
+describe('useMarkdown — KaTeX inline', () => {
+  it('renders \\( ... \\) inline math', () => {
+    const html = render('derivative of \\(\\sin(x)\\) is cool')
+    expect(html).toContain('class="katex"')
+  })
+
+  it('renders $ ... $ inline math', () => {
+    const html = render('Euler: $e^{i\\pi} + 1 = 0$')
+    expect(html).toContain('class="katex"')
+  })
+
+  it('does not match a single $ in prose', () => {
+    const html = render('It costs $5 and $10')
+    expect(html).not.toContain('class="katex"')
+  })
+
+  it('does not match escaped \\$', () => {
+    const html = render('cost is \\$5 here')
+    expect(html).not.toContain('class="katex"')
+  })
+})
+
+describe('useMarkdown — KaTeX block', () => {
+  it('renders $$ ... $$ block math', () => {
+    const html = render('$$\nE = mc^2\n$$')
+    expect(html).toContain('class="math-block"')
+    expect(html).toContain('class="katex"')
+  })
+
+  it('renders \\[ ... \\] block math', () => {
+    const html = render('\\[\nE = mc^2\n\\]')
+    expect(html).toContain('class="math-block"')
+  })
+
+  it('renders inline $$ ... $$ on a single line', () => {
+    const html = render('$$E = mc^2$$')
+    expect(html).toContain('class="math-block"')
+  })
+})
+
+describe('useMarkdown — KaTeX extensions', () => {
+  it('renders mhchem chemistry via \\ce', () => {
+    const html = render('water: $\\ce{H2O}$')
+    expect(html).toContain('class="katex"')
+  })
+
+  it('renders physics-style \\dv macro', () => {
+    const html = render('$\\dv{x}{t}$')
+    expect(html).toContain('class="katex"')
+  })
+
+  it('renders physics-style \\pdv macro', () => {
+    const html = render('$\\pdv{f}{x}$')
+    expect(html).toContain('class="katex"')
+  })
+})
+
+describe('useMarkdown — KaTeX security', () => {
+  it('does not render \\href links (trust:false)', () => {
+    const html = render('$\\href{https://evil.example}{click}$')
+    // KaTeX produces an error span when an unknown/blocked command is used
+    expect(html).not.toContain('href=')
+  })
+
+  it('does not crash on malformed math (throwOnError:false)', () => {
+    const html = render('$\\unknownmacro{x}$')
+    expect(html).toBeTypeOf('string')
+  })
+})

--- a/fasolt.client/src/composables/useMarkdown.ts
+++ b/fasolt.client/src/composables/useMarkdown.ts
@@ -1,5 +1,6 @@
 import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
+import katexPlugin from '@/lib/markdownItKatex'
 
 const md = new MarkdownIt({
   html: false,
@@ -7,6 +8,8 @@ const md = new MarkdownIt({
   typographer: false,
   breaks: true,
 })
+
+md.use(katexPlugin)
 
 // Override image rendering to show alt-text placeholder
 md.renderer.rules.image = (tokens, idx) => {

--- a/fasolt.client/src/lib/katex.ts
+++ b/fasolt.client/src/lib/katex.ts
@@ -1,0 +1,23 @@
+import katex from 'katex'
+import 'katex/contrib/mhchem'
+
+const macros: Record<string, string> = {
+  '\\dv': '\\frac{d#1}{d#2}',
+  '\\pdv': '\\frac{\\partial #1}{\\partial #2}',
+  '\\abs': '\\left|#1\\right|',
+  '\\norm': '\\left\\|#1\\right\\|',
+}
+
+export function renderMath(src: string, displayMode: boolean): string {
+  return katex.renderToString(src, {
+    displayMode,
+    throwOnError: false,
+    errorColor: 'hsl(var(--destructive))',
+    strict: 'warn',
+    trust: false,
+    maxSize: 10,
+    maxExpand: 1000,
+    macros,
+    output: 'html',
+  })
+}

--- a/fasolt.client/src/lib/markdownItKatex.ts
+++ b/fasolt.client/src/lib/markdownItKatex.ts
@@ -1,0 +1,146 @@
+import type MarkdownIt from 'markdown-it'
+import { renderMath } from './katex'
+
+const ESC = 0x5c // \
+const DOLLAR = 0x24 // $
+const PAREN_OPEN = 0x28 // (
+const PAREN_CLOSE = 0x29 // )
+const BRACKET_OPEN = 0x5b // [
+const NEWLINE = 0x0a
+
+function isWhitespaceCharCode(code: number): boolean {
+  return code === 0x20 || code === 0x09 || code === NEWLINE || code === 0x0d
+}
+
+function inlineMath(state: any, silent: boolean): boolean {
+  const start = state.pos
+  const max = state.posMax
+  const src = state.src as string
+  if (start >= max) return false
+  const code = src.charCodeAt(start)
+
+  // \( ... \)
+  if (code === ESC && start + 1 < max && src.charCodeAt(start + 1) === PAREN_OPEN) {
+    let pos = start + 2
+    let found = -1
+    while (pos < max - 1) {
+      if (src.charCodeAt(pos) === ESC && src.charCodeAt(pos + 1) === PAREN_CLOSE) {
+        found = pos
+        break
+      }
+      pos++
+    }
+    if (found < 0) return false
+    if (!silent) {
+      const token = state.push('math_inline', 'math', 0)
+      token.markup = '\\(\\)'
+      token.content = src.slice(start + 2, found)
+    }
+    state.pos = found + 2
+    return true
+  }
+
+  // $ ... $  (not $$, not escaped, no newlines, non-space adjacent to delimiters)
+  if (code === DOLLAR) {
+    if (start > 0 && src.charCodeAt(start - 1) === ESC) return false
+    if (start + 1 < max && src.charCodeAt(start + 1) === DOLLAR) return false
+
+    const afterOpen = start + 1
+    if (afterOpen >= max) return false
+    if (isWhitespaceCharCode(src.charCodeAt(afterOpen))) return false
+
+    let pos = afterOpen
+    let found = -1
+    while (pos < max) {
+      const c = src.charCodeAt(pos)
+      if (c === NEWLINE) return false
+      if (c === DOLLAR && src.charCodeAt(pos - 1) !== ESC) {
+        if (pos > afterOpen && !isWhitespaceCharCode(src.charCodeAt(pos - 1))) {
+          found = pos
+          break
+        }
+      }
+      pos++
+    }
+    if (found < 0) return false
+    if (!silent) {
+      const token = state.push('math_inline', 'math', 0)
+      token.markup = '$'
+      token.content = src.slice(start + 1, found)
+    }
+    state.pos = found + 1
+    return true
+  }
+
+  return false
+}
+
+function blockMath(state: any, startLine: number, endLine: number, silent: boolean): boolean {
+  const startPos = state.bMarks[startLine] + state.tShift[startLine]
+  const lineMax = state.eMarks[startLine]
+  if (startPos + 1 >= lineMax) return false
+
+  const src = state.src as string
+  const c0 = src.charCodeAt(startPos)
+  const c1 = src.charCodeAt(startPos + 1)
+
+  let closeStr = ''
+  if (c0 === DOLLAR && c1 === DOLLAR) {
+    closeStr = '$$'
+  } else if (c0 === ESC && c1 === BRACKET_OPEN) {
+    closeStr = '\\]'
+  } else {
+    return false
+  }
+
+  if (silent) return true
+
+  const openLen = 2
+  const sameLineRest = src.slice(startPos + openLen, lineMax)
+  let content = ''
+  let nextLine = startLine
+
+  const sameLineCloseIdx = sameLineRest.indexOf(closeStr)
+  if (sameLineCloseIdx >= 0) {
+    content = sameLineRest.slice(0, sameLineCloseIdx)
+    nextLine = startLine + 1
+  } else {
+    content = sameLineRest + '\n'
+    nextLine = startLine + 1
+    let foundClose = false
+    while (nextLine < endLine) {
+      const lineStart = state.bMarks[nextLine] + state.tShift[nextLine]
+      const lineEnd = state.eMarks[nextLine]
+      const line = src.slice(lineStart, lineEnd)
+      const closeIdx = line.indexOf(closeStr)
+      if (closeIdx >= 0) {
+        content += line.slice(0, closeIdx)
+        nextLine++
+        foundClose = true
+        break
+      }
+      content += line + '\n'
+      nextLine++
+    }
+    if (!foundClose) return false
+  }
+
+  state.line = nextLine
+  const token = state.push('math_block', 'math', 0)
+  token.block = true
+  token.content = content.trim()
+  token.markup = closeStr
+  token.map = [startLine, nextLine]
+  return true
+}
+
+export default function katexPlugin(md: MarkdownIt) {
+  md.inline.ruler.before('escape', 'math_inline', inlineMath)
+  md.block.ruler.after('blockquote', 'math_block', blockMath, {
+    alt: ['paragraph', 'reference', 'blockquote', 'list'],
+  })
+  md.renderer.rules.math_inline = (tokens: any[], idx: number) =>
+    renderMath(tokens[idx].content, false)
+  md.renderer.rules.math_block = (tokens: any[], idx: number) =>
+    `<div class="math-block">${renderMath(tokens[idx].content, true)}</div>`
+}

--- a/fasolt.client/src/lib/utils.ts
+++ b/fasolt.client/src/lib/utils.ts
@@ -10,6 +10,10 @@ export function cn(...inputs: ClassValue[]) {
 
 export function stripMarkdown(text: string): string {
   return text
+    .replace(/\$\$([\s\S]+?)\$\$/g, '$1') // block math $$…$$
+    .replace(/\\\[([\s\S]+?)\\\]/g, '$1') // block math \[…\]
+    .replace(/\\\(([\s\S]+?)\\\)/g, '$1') // inline math \(…\)
+    .replace(/(?<!\\)\$([^$\n]+?)(?<!\\)\$/g, '$1') // inline math $…$
     .replace(/^```\w*\n?/gm, '')       // code block fences (open)
     .replace(/\n?```$/gm, '')           // code block fences (close)
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1') // images → alt text

--- a/fasolt.client/src/main.ts
+++ b/fasolt.client/src/main.ts
@@ -3,6 +3,7 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import './style.css'
+import 'katex/dist/katex.min.css'
 
 const app = createApp(App)
 


### PR DESCRIPTION
Closes #139 (web + MCP). iOS rendering split into #140.

## Summary

- Web: KaTeX renders math in any surface that shows card text — review screen, card detail, deck browsing, search results — alongside existing markdown.
- Supported delimiters: `\(...\)`, `$...$` (inline), `\[...\]`, `$$...$$` (block).
- mhchem extension loaded so `\ce{2H2 + O2 -> 2H2O}` and `\pu{286 kJ/mol}` work.
- Preset macros for the LaTeX `physics` package shortcuts: `\dv`, `\pdv`, `\abs`, `\norm`.
- KaTeX configured with the security options from the issue: `trust:false`, `strict:"warn"`, `maxSize:10`, `maxExpand:1000`, `throwOnError:false` (errors render in the destructive color), and `output:"html"` so DOMPurify never has to sanitize MathML.
- `stripMarkdown` strips math delimiters so list/table previews show source text instead of raw markup.
- MCP `create_cards` / `update_cards` tool descriptions and the per-property `front` / `back` / `newFront` / `newBack` `[Description]` attributes now spell out the KaTeX support (delimiters, mhchem, the four physics shortcuts, what's blocked) — replaces the prior "LaTeX is NOT rendered" wording so AI agents emit math when appropriate.
- Welcome demo deck gains a math example; dev seed adds a dedicated "LaTeX Math Tests" deck with eight cards covering calculus, linear algebra, chemistry, physics, set theory, and mixed markdown+math.

## Test plan

- [x] `npx vitest run` — 60/60 client tests pass (14 new for the markdown-it-katex plugin: delimiter parsing, mhchem, the four macros, `$5` / `\$5` escape edge cases, security defaults).
- [x] `dotnet test` — 268/268 backend tests pass.
- [x] `npm run build` — clean TypeScript build.
- [x] Browser pass via Playwright on the dev seed's "LaTeX Math Tests" deck:
  - [x] Card detail page renders inline `\(...\)`, block `$$...$$`, mhchem `\ce{...}` with a proper chem arrow, `\pu{...}` units, and the four physics macros (`\dv`, `\pdv`, `\abs`, `\norm`).
  - [x] Review screen renders both front and back — flip works, math renders both sides.
  - [x] Deck list / card list show plain-text previews with delimiters stripped.
  - [x] No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)