### PR TITLE
Move shared MCP guidance to ServerInstructions; drop natural-key update path

### DIFF
--- a/fasolt.Server/Api/McpTools/CardTools.cs
+++ b/fasolt.Server/Api/McpTools/CardTools.cs
@@ -52,9 +52,9 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
         return JsonSerializer.Serialize(result, McpJson.Options);
     }
 
-    [McpServerTool, Description("Create one or more flashcards, optionally linked to a source file and/or deck. Each card can include SVG images for front and/or back (use a landscape viewBox like '0 0 400 250' for best display). Returns created cards, any skipped duplicates, and a deckUrl deep link if a deck was used.")]
+    [McpServerTool, Description("Create one or more flashcards, optionally linked to a source file and/or deck. Returns created cards, any skipped duplicates, and a deckUrl deep link if a deck was used.")]
     public async Task<string> CreateCards(
-        [Description("Array of cards to create. Each card needs 'front' and 'back' text, plus optional 'sourceFile' and 'sourceHeading'.")] List<BulkCardItem> cards,
+        [Description("Array of cards to create.")] List<BulkCardItem> cards,
         [Description("Default source file name for all cards (individual cards can override)")] string? sourceFile = null,
         [Description("Add cards to this deck ID")] string? deckId = null)
     {
@@ -98,9 +98,9 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
         return JsonSerializer.Serialize(new { deleted = count > 0, deletedCount = count }, McpJson.Options);
     }
 
-    [McpServerTool, Description("Update one or more existing cards' text or source metadata. Preserves all review/SRS history. Each card can be looked up by cardId, or by sourceFile + front (case-insensitive natural key).")]
+    [McpServerTool, Description("Update one or more existing cards' text or source metadata by cardId. Preserves all review/SRS history.")]
     public async Task<string> UpdateCards(
-        [Description("Array of card updates. Each needs a lookup key (cardId, or sourceFile + front) and at least one field to update (newFront, newBack, newSourceFile, newSourceHeading, newFrontSvg, newBackSvg).")] List<BulkUpdateCardItem> cards)
+        [Description("Array of card updates. Each needs a cardId and at least one field to update (newFront, newBack, newSourceFile, newSourceHeading, newFrontSvg, newBackSvg).")] List<BulkUpdateCardItem> cards)
     {
         var userId = McpUserResolver.GetUserId(httpContextAccessor);
 
@@ -115,11 +115,11 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
         }, McpJson.Options);
     }
 
-    [McpServerTool, Description("Add an SVG image to a card. LLMs can generate SVG diagrams, charts, chemical structures, math visualizations, etc. The SVG is sanitized server-side for security. Use a landscape viewBox like '0 0 400 250' for best display across web and mobile.")]
+    [McpServerTool, Description("Add an SVG image to a card. Useful for generating diagrams, charts, chemical structures, or math visualizations.")]
     public async Task<string> AddSvgToCard(
         [Description("Card ID")] string cardId,
         [Description("Which side: 'front' or 'back'")] string side,
-        [Description("Raw SVG markup (must start with <svg). Use a landscape viewBox (e.g. '0 0 400 250') — avoid square or portrait ratios as they may be clipped on mobile.")] string svg)
+        [Description("Raw SVG markup (must start with <svg).")] string svg)
     {
         var userId = McpUserResolver.GetUserId(httpContextAccessor);
 

--- a/fasolt.Server/Api/McpTools/OverviewTools.cs
+++ b/fasolt.Server/Api/McpTools/OverviewTools.cs
@@ -8,7 +8,7 @@ namespace Fasolt.Server.Api.McpTools;
 [McpServerToolType]
 public class OverviewTools(OverviewService overviewService, IHttpContextAccessor httpContextAccessor)
 {
-    [McpServerTool, Description("Get an overview of the user's account: total cards, due cards, cards by state, deck count, and source file count. Call this first to orient yourself.")]
+    [McpServerTool, Description("Get an overview of the user's account: total cards, due cards, cards by state, deck count, and source file count.")]
     public async Task<string> GetOverview()
     {
         var userId = McpUserResolver.GetUserId(httpContextAccessor);

--- a/fasolt.Server/Application/Dtos/BulkCardDtos.cs
+++ b/fasolt.Server/Application/Dtos/BulkCardDtos.cs
@@ -4,15 +4,15 @@ namespace Fasolt.Server.Application.Dtos;
 
 public record BulkCreateCardsRequest(string? SourceFile, string? DeckId, List<BulkCardItem> Cards);
 public record BulkCardItem(
-    [property: Description("Front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX/math (e.g. $...$) is NOT rendered. Example: \"What is the **capital** of France?\"")]
+    [property: Description("Front of the card (question/prompt). Markdown — see server instructions.")]
     string Front,
-    [property: Description("Back of the card (answer/explanation). Same Markdown features as `front`. Use line breaks and lists for readability. HTML and LaTeX are NOT rendered. Example: \"**Empiricism**: all knowledge stems from sense experience. *Tabula rasa* (Locke). Key figures: Locke, Berkeley, Hume.\"")]
+    [property: Description("Back of the card (answer/explanation). Markdown — see server instructions.")]
     string Back,
     string? SourceFile = null,
     string? SourceHeading = null,
-    [property: Description("Optional inline SVG for the front. Must start with `<svg`. Sanitized server-side: <style>, <script>, <foreignObject>, all event handlers (on*), the `style` attribute, `font-weight`, `font-style`, and external `href` values are stripped. For emphasis use `fill`, `stroke`, or `font-size` — bold/italic via CSS will not survive. Allowed tags include: svg, g, defs, path, circle, rect, line, polyline, polygon, ellipse, text, tspan, use, marker, symbol, linearGradient, radialGradient, stop, filter, feGaussianBlur, feOffset, feMerge, feMergeNode, clipPath, mask, pattern, title, desc. Use a landscape viewBox like '0 0 400 250'. Max ~1MB.")]
+    [property: Description("Optional inline SVG for the front. See server instructions for sanitization rules and viewBox guidance.")]
     string? FrontSvg = null,
-    [property: Description("Optional inline SVG for the back. Same sanitization rules as `frontSvg`.")]
+    [property: Description("Optional inline SVG for the back. Same rules as frontSvg.")]
     string? BackSvg = null);
 public record BulkCreateCardsResponse(List<CardDto> Created, List<SkippedCardDto> Skipped);
 public record SkippedCardDto(string Front, string Reason);

--- a/fasolt.Server/Application/Dtos/CardDtos.cs
+++ b/fasolt.Server/Application/Dtos/CardDtos.cs
@@ -42,21 +42,17 @@ public record UpdateCardResult(UpdateCardStatus Status, CardDto? Card = null)
 }
 
 public record BulkUpdateCardItem(
-    [property: Description("Lookup key: card ID. Either provide this OR (sourceFile + front).")]
-    string? CardId = null,
-    [property: Description("Lookup key part 1: source file. Combine with `front` for case-insensitive natural-key lookup when `cardId` is unknown.")]
-    string? SourceFile = null,
-    [property: Description("Lookup key part 2: existing front text (case-insensitive). Combine with `sourceFile`.")]
-    string? Front = null,
-    [property: Description("New front of the card (question/prompt). Rendered as Markdown — supported: headings (#, ##, ###), **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, bullet/numbered lists, > blockquotes, tables, [links](url), and auto-linked URLs. Soft newlines are preserved as line breaks. HTML is escaped (not rendered). LaTeX/math (e.g. $...$) is NOT rendered. Example: \"What is the **capital** of France?\"")]
+    [property: Description("Card ID to update. Required. Use list_cards or search_cards to discover IDs.")]
+    string CardId,
+    [property: Description("New front of the card. Markdown — see server instructions.")]
     string? NewFront = null,
-    [property: Description("New back of the card (answer/explanation). Same Markdown features as `newFront`. HTML and LaTeX are NOT rendered. Example: \"**Empiricism**: all knowledge stems from sense experience. *Tabula rasa* (Locke). Key figures: Locke, Berkeley, Hume.\"")]
+    [property: Description("New back of the card. Markdown — see server instructions.")]
     string? NewBack = null,
     string? NewSourceFile = null,
     string? NewSourceHeading = null,
-    [property: Description("New inline SVG for the front. Must start with `<svg`. Sanitized server-side: <style>, <script>, <foreignObject>, all event handlers (on*), the `style` attribute, `font-weight`, `font-style`, and external `href` values are stripped. For emphasis use `fill`, `stroke`, or `font-size` — bold/italic via CSS will not survive. Allowed tags include: svg, g, defs, path, circle, rect, line, polyline, polygon, ellipse, text, tspan, use, marker, symbol, linearGradient, radialGradient, stop, filter, feGaussianBlur, feOffset, feMerge, feMergeNode, clipPath, mask, pattern, title, desc. Use a landscape viewBox like '0 0 400 250'. Max ~1MB.")]
+    [property: Description("New inline SVG for the front. See server instructions.")]
     string? NewFrontSvg = null,
-    [property: Description("New inline SVG for the back. Same sanitization rules as `newFrontSvg`.")]
+    [property: Description("New inline SVG for the back. Same rules as newFrontSvg.")]
     string? NewBackSvg = null);
 
-public record BulkUpdateCardResult(string? CardId, string? SourceFile, string? Front, UpdateCardStatus Status, CardDto? Card = null);
+public record BulkUpdateCardResult(string CardId, UpdateCardStatus Status, CardDto? Card = null);

--- a/fasolt.Server/Application/Services/CardService.cs
+++ b/fasolt.Server/Application/Services/CardService.cs
@@ -305,20 +305,6 @@ public class CardService(AppDbContext db)
         return await ApplyCardFieldUpdates(userId, card, req);
     }
 
-    public async Task<UpdateCardResult> UpdateCardByNaturalKey(string userId, string sourceFile, string front, UpdateCardFieldsRequest req)
-    {
-        var card = await db.Cards
-            .Include(c => c.DeckCards).ThenInclude(dc => dc.Deck)
-            .FirstOrDefaultAsync(c => c.UserId == userId
-                && c.SourceFile != null
-                && c.SourceFile.ToLower() == sourceFile.ToLower()
-                && c.Front.ToLower() == front.ToLower());
-
-        if (card is null) return UpdateCardResult.NotFound();
-
-        return await ApplyCardFieldUpdates(userId, card, req);
-    }
-
     public async Task<List<BulkUpdateCardResult>> BulkUpdateCards(string userId, List<BulkUpdateCardItem> items)
     {
         var results = new List<BulkUpdateCardResult>();
@@ -326,23 +312,8 @@ public class CardService(AppDbContext db)
         foreach (var item in items)
         {
             var req = new UpdateCardFieldsRequest(item.NewFront, item.NewBack, item.NewSourceFile, item.NewSourceHeading, item.NewFrontSvg, item.NewBackSvg);
-
-            UpdateCardResult result;
-            if (item.CardId is not null)
-            {
-                result = await UpdateCardFields(userId, item.CardId, req);
-            }
-            else if (item.SourceFile is not null && item.Front is not null)
-            {
-                result = await UpdateCardByNaturalKey(userId, item.SourceFile, item.Front, req);
-            }
-            else
-            {
-                results.Add(new BulkUpdateCardResult(item.CardId, item.SourceFile, item.Front, UpdateCardStatus.NotFound));
-                continue;
-            }
-
-            results.Add(new BulkUpdateCardResult(item.CardId, item.SourceFile, item.Front, result.Status, result.Card));
+            var result = await UpdateCardFields(userId, item.CardId, req);
+            results.Add(new BulkUpdateCardResult(item.CardId, result.Status, result.Card));
         }
 
         return results;

--- a/fasolt.Server/Program.cs
+++ b/fasolt.Server/Program.cs
@@ -372,7 +372,39 @@ builder.Services.AddFSRS(options =>
 
 builder.Services.AddHttpContextAccessor();
 
-builder.Services.AddMcpServer()
+builder.Services.AddMcpServer(options =>
+    {
+        options.ServerInstructions = """
+            Fasolt is a spaced-repetition flashcard app. Use these tools to create and
+            manage cards — either extracted from the user's notes (with sourceFile /
+            sourceHeading provenance) or generated directly. Users review the resulting
+            cards on the web/iOS app.
+
+            # Card text format
+            All card text fields (front, back, newFront, newBack) render as Markdown:
+            headings, **bold**, *italic*, ~~strike~~, `code`, fenced code blocks, lists,
+            blockquotes, tables, [links](url). Soft newlines are preserved. HTML is escaped
+            (not rendered). LaTeX/math is not currently supported.
+
+            # SVG images
+            All inline-SVG inputs (frontSvg, backSvg, newFrontSvg, newBackSvg, and the
+            svg parameter of add_svg_to_card) must start with <svg>. The server sanitizes input: <script>,
+            <style>, <foreignObject>, event handlers (on*), the style attribute, font-weight,
+            font-style, and external href values are stripped. For emphasis use fill, stroke,
+            or font-size attributes — CSS-based bold/italic will not survive sanitization.
+            Use a landscape viewBox like '0 0 400 250'; square/portrait may be clipped on
+            mobile. Max ~1MB.
+
+            # Recommended workflow
+            1. Call get_overview first to orient on the user's account.
+            2. Before bulk-creating cards, call search_cards to detect duplicates.
+            3. update_cards preserves SRS history; prefer it over delete + create.
+            4. Call create_snapshot before large or destructive bulk operations
+               (delete_cards, sweeping update_cards, deck deletes). Snapshots are
+               cheap — skipped if nothing changed — and let the user restore at
+               https://fasolt.app if the change was wrong.
+            """;
+    })
     .WithHttpTransport()
     .AddAuthorizationFilters()
     .WithToolsFromAssembly();

--- a/fasolt.Tests/CardServiceTests.cs
+++ b/fasolt.Tests/CardServiceTests.cs
@@ -223,23 +223,6 @@ public class CardServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task UpdateCardByNaturalKey_CaseInsensitive()
-    {
-        await using var db = _db.CreateDbContext();
-        var svc = new CardService(db);
-
-        await svc.CreateCard(UserId, "What is DNA?", "Deoxyribonucleic acid", "biology.md", "Basics");
-
-        // Look up with different casing
-        var result = await svc.UpdateCardByNaturalKey(UserId, "Biology.MD", "what is dna?",
-            new UpdateCardFieldsRequest(NewBack: "Updated answer"));
-
-        result.Status.Should().Be(UpdateCardStatus.Success);
-        result.Card!.Back.Should().Be("Updated answer");
-        result.Card.Front.Should().Be("What is DNA?"); // original casing preserved
-    }
-
-    [Fact]
     public async Task UpdateCardFields_RejectsCollision()
     {
         await using var db = _db.CreateDbContext();
@@ -365,27 +348,6 @@ public class CardServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task BulkUpdateCards_ByNaturalKey_UpdatesMultiple()
-    {
-        await using var db = _db.CreateDbContext();
-        var svc = new CardService(db);
-
-        await svc.CreateCard(UserId, "NK-A", "Old A", "nk.md", null);
-        await svc.CreateCard(UserId, "NK-B", "Old B", "nk.md", null);
-
-        var results = await svc.BulkUpdateCards(UserId,
-        [
-            new BulkUpdateCardItem(SourceFile: "nk.md", Front: "NK-A", NewBack: "Updated A"),
-            new BulkUpdateCardItem(SourceFile: "nk.md", Front: "NK-B", NewBack: "Updated B"),
-        ]);
-
-        results.Should().HaveCount(2);
-        results.Should().AllSatisfy(r => r.Status.Should().Be(UpdateCardStatus.Success));
-        results[0].Card!.Back.Should().Be("Updated A");
-        results[1].Card!.Back.Should().Be("Updated B");
-    }
-
-    [Fact]
     public async Task BulkUpdateCards_MixedResults()
     {
         await using var db = _db.CreateDbContext();
@@ -397,13 +359,11 @@ public class CardServiceTests : IAsyncLifetime
         [
             new BulkUpdateCardItem(CardId: card.Id, NewBack: "Updated"),
             new BulkUpdateCardItem(CardId: "nonexistent", NewBack: "Nope"),
-            new BulkUpdateCardItem(SourceFile: null, Front: null, NewBack: "Invalid"),
         ]);
 
-        results.Should().HaveCount(3);
+        results.Should().HaveCount(2);
         results[0].Status.Should().Be(UpdateCardStatus.Success);
         results[1].Status.Should().Be(UpdateCardStatus.NotFound);
-        results[2].Status.Should().Be(UpdateCardStatus.NotFound);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Adds **`ServerInstructions`** to the MCP registration. This is where cross-tool guidance belongs (per the [MCP blog's do/don'ts](https://blog.modelcontextprotocol.io/posts/2025-11-03-using-server-instructions/)) — Markdown card-text conventions, SVG sanitization rules, and recommended workflow (overview → search → snapshot before destructive ops).
- **Trims per-tool descriptions** that duplicated server instructions: SVG/viewBox advice removed from `create_cards`, `add_svg_to_card`, the `svg` parameter, and \`BulkCardItem\` / \`BulkUpdateCardItem\` parameter descriptions; \"Call this first to orient\" removed from `get_overview` (now in workflow step 1).
- **Drops the `sourceFile + front` natural-key lookup** from `BulkUpdateCardItem` and removes the `UpdateCardByNaturalKey` method. Lookup is now `cardId`-only — simpler schema, one fewer code path. The natural-key only worked when `front` was *unchanged*, so it covered a narrow case in exchange for a doubled API surface.
- **Keeps** `UpdateCardStatus.Collision` and the collision check in `ApplyCardFieldUpdates` — cardId-based updates that change `front` or `sourceFile` can still produce duplicate `(sourceFile, front)` tuples, and that check enforces the same idempotency invariant the create path relies on for safe re-imports.

Net: 7 files changed, 54 insertions, 95 deletions.

## Test plan

- [x] `dotnet build fasolt.sln` clean (0 warnings, 0 errors)
- [x] `dotnet test --filter CardServiceTests` — 26 passed (incl. `UpdateCardFields_RejectsCollision`, `UpdateCardFields_SourceFileChangeCollision`, `BulkUpdateCards_ById_UpdatesMultiple`, `BulkUpdateCards_MixedResults`)
- [ ] Smoke-test the MCP server: `initialize` returns the new `instructions` field; `tools/list` returns the trimmed descriptions; `update_cards` works with cardId-only items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)