### PR TITLE
iOS: swipe between deck cards; tighten study spacing

### DIFF
--- a/fasolt.Server/fasolt.Server.csproj
+++ b/fasolt.Server/fasolt.Server.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Fasolt.Server</RootNamespace>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/fasolt.client/package-lock.json
+++ b/fasolt.client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fasolt.client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fasolt.client",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@tanstack/vue-table": "^8.21.3",
         "@vueuse/core": "^14.2.1",

--- a/fasolt.client/package.json
+++ b/fasolt.client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fasolt.client",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/fasolt.ios/Fasolt.xcodeproj/project.pbxproj
+++ b/fasolt.ios/Fasolt.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		6158F7086E448D8D1D00D777 /* StudyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DB69B316FF51F7EC607EBD /* StudyView.swift */; };
 		6F1A4C6F09CB0E465B1CA3BD /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82812F20EB20898654E7FABF /* CardView.swift */; };
 		7A76E15518841EAEC7BC1AB7 /* CardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11E2D8B1C02F8D7A23A3F6E /* CardDetailView.swift */; };
+		7F8E9D0C1B2A3948576655AA /* PagedCardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9D0C1B2A39485766554433 /* PagedCardDetailView.swift */; };
 		7BCD4493139B55A2D9620DE0 /* DeckDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CCAF32BF109E57F03DF3E8 /* DeckDetailView.swift */; };
 		82E3A6C6D13F59A284095235 /* FasoltApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D826424A31F1413445EC6650 /* FasoltApp.swift */; };
 		8AAC264CB92F9AEE3F6E1020 /* NotificationSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B7A226C2BB777883E5F019 /* NotificationSettingsViewModel.swift */; };
@@ -132,6 +133,7 @@
 		DB1B7BD816596315056373C3 /* FasoltTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FasoltTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD44556677889900AABB11DD /* DeckFormSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckFormSheet.swift; sourceTree = "<group>"; };
 		E11E2D8B1C02F8D7A23A3F6E /* CardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDetailView.swift; sourceTree = "<group>"; };
+		8E9D0C1B2A39485766554433 /* PagedCardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedCardDetailView.swift; sourceTree = "<group>"; };
 		E1F0E793E14821102B85EE20 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 		E2686816B7E21E3DB2171066 /* CardHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardHelpers.swift; sourceTree = "<group>"; };
 		FEFCB24046F998F4F8AA78BB /* AuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthServiceTests.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				E11E2D8B1C02F8D7A23A3F6E /* CardDetailView.swift */,
 				E2686816B7E21E3DB2171066 /* CardHelpers.swift */,
 				69E947CBD44E199505935FEF /* OfflineBanner.swift */,
+				8E9D0C1B2A39485766554433 /* PagedCardDetailView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -477,6 +480,7 @@
 				D578E86690C15FA330A7530A /* Card.swift in Sources */,
 				0E6689B273299365D24C6243 /* CardDetailSheet.swift in Sources */,
 				7A76E15518841EAEC7BC1AB7 /* CardDetailView.swift in Sources */,
+				7F8E9D0C1B2A3948576655AA /* PagedCardDetailView.swift in Sources */,
 				1F108C44139D54CBA1C25505 /* CardHelpers.swift in Sources */,
 				AA22334455667788990011BB /* CardFormSheet.swift in Sources */,
 				562490CD564C9738BBDE48A4 /* CardListView.swift in Sources */,

--- a/fasolt.ios/Fasolt.xcodeproj/project.pbxproj
+++ b/fasolt.ios/Fasolt.xcodeproj/project.pbxproj
@@ -29,8 +29,8 @@
 		6158F7086E448D8D1D00D777 /* StudyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DB69B316FF51F7EC607EBD /* StudyView.swift */; };
 		6F1A4C6F09CB0E465B1CA3BD /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82812F20EB20898654E7FABF /* CardView.swift */; };
 		7A76E15518841EAEC7BC1AB7 /* CardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11E2D8B1C02F8D7A23A3F6E /* CardDetailView.swift */; };
-		7F8E9D0C1B2A3948576655AA /* PagedCardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9D0C1B2A39485766554433 /* PagedCardDetailView.swift */; };
 		7BCD4493139B55A2D9620DE0 /* DeckDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CCAF32BF109E57F03DF3E8 /* DeckDetailView.swift */; };
+		7F8E9D0C1B2A3948576655AA /* PagedCardDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9D0C1B2A39485766554433 /* PagedCardDetailView.swift */; };
 		82E3A6C6D13F59A284095235 /* FasoltApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D826424A31F1413445EC6650 /* FasoltApp.swift */; };
 		8AAC264CB92F9AEE3F6E1020 /* NotificationSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B7A226C2BB777883E5F019 /* NotificationSettingsViewModel.swift */; };
 		8ECAC149086A23E54D5DC1D2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CE0A6615C77BF475BDCC9074 /* Assets.xcassets */; };
@@ -105,6 +105,7 @@
 		82812F20EB20898654E7FABF /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		85974CB3F7C04CBAA15AB0A9 /* FeatureFlagsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsService.swift; sourceTree = "<group>"; };
 		876CBB32009796B1341C8D59 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		8E9D0C1B2A39485766554433 /* PagedCardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedCardDetailView.swift; sourceTree = "<group>"; };
 		906491E8E4E7A3757F2331DB /* String+StripMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+StripMarkdown.swift"; sourceTree = "<group>"; };
 		9097BB7014F064BF83F77689 /* DeckCardRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckCardRow.swift; sourceTree = "<group>"; };
 		933F9C08DEBB1C1DE4B0F805 /* Fasolt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Fasolt.entitlements; sourceTree = "<group>"; };
@@ -133,7 +134,6 @@
 		DB1B7BD816596315056373C3 /* FasoltTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FasoltTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD44556677889900AABB11DD /* DeckFormSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckFormSheet.swift; sourceTree = "<group>"; };
 		E11E2D8B1C02F8D7A23A3F6E /* CardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDetailView.swift; sourceTree = "<group>"; };
-		8E9D0C1B2A39485766554433 /* PagedCardDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedCardDetailView.swift; sourceTree = "<group>"; };
 		E1F0E793E14821102B85EE20 /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 		E2686816B7E21E3DB2171066 /* CardHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardHelpers.swift; sourceTree = "<group>"; };
 		FEFCB24046F998F4F8AA78BB /* AuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthServiceTests.swift; sourceTree = "<group>"; };
@@ -642,7 +642,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fasolt.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -660,7 +660,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fasolt.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/fasolt.ios/Fasolt/Views/Decks/DeckDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Decks/DeckDetailView.swift
@@ -65,17 +65,7 @@ struct DeckDetailView: View {
                             Section("Cards") {
                                 ForEach(sortedCards(detail.cards, by: sortOrder), id: \.id) { card in
                                     NavigationLink {
-                                        CardDetailView(
-                                            card: card,
-                                            currentDeckId: viewModel.deckId,
-                                            availableDecks: availableDecks,
-                                            onSaveEdit: { request in
-                                                try await viewModel.updateCard(id: card.id, request)
-                                            },
-                                            onToggleSuspended: { isSuspended in
-                                                try await viewModel.setCardSuspended(id: card.id, isSuspended: isSuspended)
-                                            }
-                                        )
+                                        pagedDestination(for: card, in: detail)
                                     } label: {
                                         DeckCardRow(card: card, showSourceFile: true)
                                     }
@@ -247,4 +237,19 @@ struct DeckDetailView: View {
         }
     }
 
+    @ViewBuilder
+    private func pagedDestination(for card: DeckCardDTO, in detail: DeckDetailDTO) -> some View {
+        PagedCardDetailView(
+            cards: sortedCards(detail.cards, by: sortOrder),
+            initialCardId: card.id,
+            currentDeckId: viewModel.deckId,
+            availableDecks: availableDecks,
+            onSaveEdit: { id, request in
+                try await viewModel.updateCard(id: id, request)
+            },
+            onToggleSuspended: { id, isSuspended in
+                try await viewModel.setCardSuspended(id: id, isSuspended: isSuspended)
+            }
+        )
+    }
 }

--- a/fasolt.ios/Fasolt/Views/Shared/CardDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/CardDetailView.swift
@@ -8,7 +8,7 @@ struct CardDetailView: View {
     var availableDecks: [DeckDTO] = []
     var onSaveEdit: ((UpdateCardRequest) async throws -> Void)?
     var onToggleSuspended: ((Bool) async throws -> Void)?
-    var showsEditButton: Bool = true
+    var showsToolbarActions: Bool = true
 
     @State private var showEditSheet = false
 
@@ -121,12 +121,22 @@ struct CardDetailView: View {
         .navigationTitle("Card")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            if showsEditButton, onSaveEdit != nil {
+            if showsToolbarActions {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
-                        showEditSheet = true
+                        UIPasteboard.general.string = card.id
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     } label: {
-                        Label("Edit", systemImage: "pencil")
+                        Label("Copy ID", systemImage: "doc.on.doc")
+                    }
+                }
+                if onSaveEdit != nil {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            showEditSheet = true
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
                     }
                 }
             }

--- a/fasolt.ios/Fasolt/Views/Shared/CardDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/CardDetailView.swift
@@ -8,6 +8,7 @@ struct CardDetailView: View {
     var availableDecks: [DeckDTO] = []
     var onSaveEdit: ((UpdateCardRequest) async throws -> Void)?
     var onToggleSuspended: ((Bool) async throws -> Void)?
+    var showsEditButton: Bool = true
 
     @State private var showEditSheet = false
 
@@ -120,7 +121,7 @@ struct CardDetailView: View {
         .navigationTitle("Card")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            if onSaveEdit != nil {
+            if showsEditButton, onSaveEdit != nil {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         showEditSheet = true

--- a/fasolt.ios/Fasolt/Views/Shared/CardHelpers.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/CardHelpers.swift
@@ -3,6 +3,7 @@ import SwiftUI
 // MARK: - CardDisplayable Protocol
 
 protocol CardDisplayable {
+    var id: String { get }
     var front: String { get }
     var back: String { get }
     var sourceFile: String? { get }

--- a/fasolt.ios/Fasolt/Views/Shared/PagedCardDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/PagedCardDetailView.swift
@@ -47,7 +47,7 @@ struct PagedCardDetailView: View {
                     onToggleSuspended: { isSuspended in
                         try await onToggleSuspended(card.id, isSuspended)
                     },
-                    showsEditButton: false
+                    showsToolbarActions: false
                 )
                 .tag(card.id)
             }
@@ -63,6 +63,17 @@ struct PagedCardDetailView: View {
                         .foregroundStyle(.secondary)
                         .monospacedDigit()
                 }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    if let id = currentCard?.id {
+                        UIPasteboard.general.string = id
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    }
+                } label: {
+                    Label("Copy ID", systemImage: "doc.on.doc")
+                }
+                .disabled(currentCard == nil)
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button {

--- a/fasolt.ios/Fasolt/Views/Shared/PagedCardDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/PagedCardDetailView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct PagedCardDetailView: View {
+    let cards: [DeckCardDTO]
+    let currentDeckId: String?
+    let availableDecks: [DeckDTO]
+    let onSaveEdit: (String, UpdateCardRequest) async throws -> Void
+    let onToggleSuspended: (String, Bool) async throws -> Void
+
+    @State private var selectedId: String
+
+    init(
+        cards: [DeckCardDTO],
+        initialCardId: String,
+        currentDeckId: String?,
+        availableDecks: [DeckDTO],
+        onSaveEdit: @escaping (String, UpdateCardRequest) async throws -> Void,
+        onToggleSuspended: @escaping (String, Bool) async throws -> Void
+    ) {
+        self.cards = cards
+        self.currentDeckId = currentDeckId
+        self.availableDecks = availableDecks
+        self.onSaveEdit = onSaveEdit
+        self.onToggleSuspended = onToggleSuspended
+        _selectedId = State(initialValue: initialCardId)
+    }
+
+    private var currentIndex: Int {
+        cards.firstIndex(where: { $0.id == selectedId }) ?? 0
+    }
+
+    var body: some View {
+        TabView(selection: $selectedId) {
+            ForEach(cards, id: \.id) { card in
+                CardDetailView(
+                    card: card,
+                    currentDeckId: currentDeckId,
+                    availableDecks: availableDecks,
+                    onSaveEdit: { request in
+                        try await onSaveEdit(card.id, request)
+                    },
+                    onToggleSuspended: { isSuspended in
+                        try await onToggleSuspended(card.id, isSuspended)
+                    }
+                )
+                .tag(card.id)
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                VStack(spacing: 0) {
+                    Text("Card")
+                        .font(.headline)
+                    Text("\(currentIndex + 1) / \(cards.count)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+        }
+    }
+}

--- a/fasolt.ios/Fasolt/Views/Shared/PagedCardDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/PagedCardDetailView.swift
@@ -8,6 +8,7 @@ struct PagedCardDetailView: View {
     let onToggleSuspended: (String, Bool) async throws -> Void
 
     @State private var selectedId: String
+    @State private var showEditSheet = false
 
     init(
         cards: [DeckCardDTO],
@@ -29,6 +30,10 @@ struct PagedCardDetailView: View {
         cards.firstIndex(where: { $0.id == selectedId }) ?? 0
     }
 
+    private var currentCard: DeckCardDTO? {
+        cards.first(where: { $0.id == selectedId })
+    }
+
     var body: some View {
         TabView(selection: $selectedId) {
             ForEach(cards, id: \.id) { card in
@@ -41,7 +46,8 @@ struct PagedCardDetailView: View {
                     },
                     onToggleSuspended: { isSuspended in
                         try await onToggleSuspended(card.id, isSuspended)
-                    }
+                    },
+                    showsEditButton: false
                 )
                 .tag(card.id)
             }
@@ -57,6 +63,42 @@ struct PagedCardDetailView: View {
                         .foregroundStyle(.secondary)
                         .monospacedDigit()
                 }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showEditSheet = true
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+                .disabled(currentCard == nil)
+            }
+        }
+        .sheet(isPresented: $showEditSheet) {
+            if let card = currentCard {
+                CardFormSheet(
+                    mode: .edit(
+                        front: card.front,
+                        back: card.back,
+                        sourceFile: card.sourceFile,
+                        sourceHeading: card.sourceHeading,
+                        deckId: currentDeckId,
+                        isSuspended: card.isSuspended
+                    ),
+                    decks: availableDecks,
+                    onSave: { request, deckId in
+                        let updateRequest = UpdateCardRequest(
+                            front: request.front,
+                            back: request.back,
+                            sourceFile: request.sourceFile,
+                            sourceHeading: request.sourceHeading,
+                            deckIds: deckId.map { [$0] }
+                        )
+                        try await onSaveEdit(card.id, updateRequest)
+                    },
+                    onToggleSuspended: { isSuspended in
+                        try await onToggleSuspended(card.id, isSuspended)
+                    }
+                )
             }
         }
     }

--- a/fasolt.ios/Fasolt/Views/Study/CardView.swift
+++ b/fasolt.ios/Fasolt/Views/Study/CardView.swift
@@ -14,14 +14,12 @@ struct CardView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Spacer()
-
             Text(label)
                 .font(.caption2)
                 .textCase(.uppercase)
                 .tracking(1)
                 .foregroundStyle(.secondary)
-                .padding(.bottom, 12)
+                .padding(.bottom, 8)
 
             if let questionText {
                 StructuredText(markdown: questionText)
@@ -34,7 +32,7 @@ struct CardView: View {
             if let svg {
                 SvgView(svg: svg)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 300)
+                    .frame(height: 240)
                     .padding(.bottom, 8)
             }
 
@@ -43,10 +41,9 @@ struct CardView: View {
                     .font(.title3)
                     .foregroundStyle(.primary)
                     .padding(.horizontal, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .scrollBounceBehavior(.basedOnSize)
-
-            Spacer()
 
             VStack(alignment: .leading, spacing: 2) {
                 if let sourceFile {
@@ -75,11 +72,11 @@ struct CardView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .font(.caption2)
             .foregroundStyle(.tertiary)
-            .padding(.bottom, 4)
+            .padding(.top, 8)
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 16)
-        .padding(.vertical, 24)
+        .padding(.vertical, 14)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
         .overlay(
             RoundedRectangle(cornerRadius: 16)


### PR DESCRIPTION
## Summary

Closes #134 and #143.

**#134 — Swipe between cards in a deck (iOS)**
- New `PagedCardDetailView` wraps `CardDetailView` in a paged `TabView` (`.page` style). Opening a card from `DeckDetailView` lets you swipe horizontally through the deck's cards in the current sort order.
- Position indicator ("2 / 4") shown in the nav bar via a `.principal` toolbar item.
- Cards opened from non-deck contexts (search, all cards, etc.) still use the plain `CardDetailView` — no swipe nav there.
- Each page keeps its own Edit button / edit sheet state, so editing the visible card works the same as before.

**#143 — Wasted vertical space on the study card**
- Dropped the two `Spacer()`s inside `CardView` that pushed content to the top/bottom of the card border (visible as the yellow zones in the screenshot).
- Shrank the SVG slot from `300pt` → `240pt` so the SVG-bearing card doesn't reserve a half-screen block when the SVG is small.
- Reduced the card's outer vertical padding (`24` → `14`) and the label's bottom padding (`12` → `8`).

## Test plan

- [ ] Open a deck with multiple cards. Tap a card. Swipe left/right — the next/previous card slides in. Position indicator updates.
- [ ] Verify it stops at the first/last card (TabView default rubber-bands).
- [ ] Tap Edit while paged. The visible card's edit sheet opens. Save → list updates.
- [ ] Open a card from the All Cards list (no deck context). Verify there's no horizontal swipe nav, just the regular detail view.
- [ ] Study a deck where some cards have an SVG and some don't. Confirm the card visually fills more of the screen and the previous "yellow" gaps are gone.
- [ ] Study a card with a long answer text — make sure the answer scrolls and nothing gets cut off.
- [ ] Per the issue: try the swipe nav on a real device and only ship if it feels nice. If paging fights the back-swipe gesture, fall back to chevron buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)