### PR TITLE
Motivational study stats on dashboard (#150)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-motivational-study-stats.md
+++ b/docs/superpowers/plans/2026-05-14-motivational-study-stats.md
@@ -1,0 +1,174 @@
+# Motivational study stats — Implementation plan
+
+Spec: `docs/superpowers/specs/2026-05-14-motivational-study-stats-design.md`
+Branch: `feat/study-stats-dashboard`
+
+## API contract (locked)
+
+```
+GET /api/review/study-stats
+```
+
+Response (200):
+
+```json
+{
+  "currentStreak": 0,
+  "bestStreak": 0,
+  "totalAnswered": 0,
+  "answeredToday": 0
+}
+```
+
+All fields are non-negative integers. All four fields are always present (no nulls).
+
+## Track 1 — Backend (.NET)
+
+1. **Entity** `fasolt.Server/Domain/Entities/ReviewLog.cs`:
+   ```csharp
+   public class ReviewLog
+   {
+       public long Id { get; set; }
+       public string UserId { get; set; } = default!;
+       public AppUser User { get; set; } = default!;
+       public Guid CardId { get; set; }
+       public Card Card { get; set; } = default!;
+       public string Rating { get; set; } = default!;
+       public DateTimeOffset ReviewedAt { get; set; }
+       public DateTimeOffset? ScheduledDueAfter { get; set; }
+       public string StateAfter { get; set; } = default!;
+   }
+   ```
+
+2. **AppDbContext**: register `DbSet<ReviewLog>`, configure key + indexes:
+   - PK `Id` (long, identity)
+   - Index `(UserId, ReviewedAt)`
+   - Index `(CardId, ReviewedAt)`
+   - FK `UserId` → AppUser, OnDelete Cascade
+   - FK `CardId` → Card, OnDelete Cascade
+   - `Rating` HasMaxLength(20), `StateAfter` HasMaxLength(20)
+
+3. **AppUser**: add `public int BestStreak { get; set; } = 0;` and configure default in `OnModelCreating`.
+
+4. **Migration** named `AddReviewLogAndBestStreak`. Create with:
+   ```
+   dotnet ef migrations add AddReviewLogAndBestStreak --project fasolt.Server --output-dir Infrastructure/Data/Migrations
+   ```
+
+5. **ReviewService.RateCard**: after FSRS update, append a `ReviewLog` row before `SaveChangesAsync`. Then call `StudyStatsService.UpdateBestStreakIfNeeded(userId)` (so streak best persists). Order: log row first, then bestStreak recompute (uses freshly written log).
+
+6. **New service** `fasolt.Server/Application/Services/StudyStatsService.cs`:
+
+   Constructor: `(AppDbContext db, TimeProvider timeProvider)`.
+
+   Public methods:
+   - `Task<StudyStatsDto> GetStats(string userId)`
+   - `Task UpdateBestStreakIfNeeded(string userId)`
+
+   Algorithm for `GetStats`:
+   - Load user (for `TimeZone`, `DayStartHour`, `BestStreak`).
+   - Determine today's user-local day boundary via `DueTimeRounder.ResolveTimeZone` + `DayStartHour`.
+   - `totalAnswered = COUNT(*)` on `ReviewLogs` for user.
+   - `answeredToday = COUNT(*)` on `ReviewLogs` where ReviewedAt within `[todayStart, tomorrowStart)`.
+   - `currentStreak`: walk back day-by-day from today (max 365 iterations):
+     - Day is **study day** if any `ReviewLog` row falls within its [start, end).
+     - Day is **due day** if `EXISTS` a card created on/before day-end whose latest-known scheduled-due as of day-end ≤ day-end. Latest-known = `MAX(ReviewLog.ScheduledDueAfter)` for that card with `ReviewedAt <= dayEnd`, or `Card.CreatedAt` if none.
+     - Loop:
+       ```
+       if today is study day:
+           streak = 1
+       cursor = today - 1
+       while cursor >= cutoff:
+           if cursor is study day: streak += 1
+           elif cursor is due day: break
+           cursor -= 1
+       ```
+   - `bestStreak = max(user.BestStreak, currentStreak)`.
+
+   `UpdateBestStreakIfNeeded`: compute current streak; if > user.BestStreak, persist new value.
+
+   **Performance note**: do the per-day "study day" and "due day" checks via batched SQL where possible. Simplest acceptable v1: fetch the set of distinct study days for the user in one query (postgres `date_trunc` or app-side bucketing of ReviewedAt). Then per-day "due day" check is one query per day during the gap-walk. Bound the walk at 365 days.
+
+7. **DTO** `fasolt.Server/Application/Dtos/StudyStatsDto.cs`:
+   ```csharp
+   public record StudyStatsDto(int CurrentStreak, int BestStreak, int TotalAnswered, int AnsweredToday);
+   ```
+
+8. **Endpoint**: in `ReviewEndpoints.cs`, add `group.MapGet("/study-stats", GetStudyStats);` and handler using `StudyStatsService`.
+
+9. **DI**: register `StudyStatsService` in `Program.cs` alongside the others.
+
+10. **Tests** `fasolt.Tests/StudyStatsServiceTests.cs`:
+    - Empty: all zeros.
+    - One review today: currentStreak=1, totalAnswered=1, answeredToday=1, bestStreak=1.
+    - Two consecutive days: streak=2.
+    - Gap day with no due cards: streak preserved across gap (use FakeTimeProvider, rate easy to push due far out, jump 2 days, rate again on a new card created the next day — verify streak counts 2 with a no-due gap between).
+    - Gap day with due cards but no review: streak breaks.
+    - BestStreak persists when current streak resets.
+
+## Track 2 — Web frontend (Vue)
+
+1. **Type** `fasolt.client/src/types/index.ts`: add
+   ```ts
+   export interface StudyStats {
+     currentStreak: number
+     bestStreak: number
+     totalAnswered: number
+     answeredToday: number
+   }
+   ```
+
+2. **Store** `fasolt.client/src/stores/review.ts`: add
+   ```ts
+   async function fetchStudyStats(): Promise<StudyStats> {
+     return apiFetch<StudyStats>('/review/study-stats')
+   }
+   ```
+   Return it from the store.
+
+3. **View** `fasolt.client/src/views/StudyView.vue`:
+   - Add `studyStats` ref `{ currentStreak: 0, bestStreak: 0, totalAnswered: 0, answeredToday: 0 }`.
+   - Fetch in `onMounted` parallel with `fetchStats()`.
+   - Render under the existing CTA, before the "Study by deck" section.
+   - Layout — a small horizontally-arranged row of four stats with the streak emphasized:
+     ```
+     [🔥 7]            482            12            14
+     day streak        answered       today         best
+     ```
+   - Use existing typography (Tailwind classes already in this file).
+   - If `totalAnswered === 0`, hide the row (users with no review history don't need it).
+
+## Track 3 — iOS frontend
+
+1. **DTO** `fasolt.ios/Fasolt/Models/APIModels.swift`: add
+   ```swift
+   struct StudyStatsDTO: Decodable, Sendable {
+       let currentStreak: Int
+       let bestStreak: Int
+       let totalAnswered: Int
+       let answeredToday: Int
+   }
+   ```
+
+2. **ViewModel** `fasolt.ios/Fasolt/ViewModels/DashboardViewModel.swift`:
+   - Add `var studyStats: StudyStatsDTO?`.
+   - In `loadStats()`, add a fourth `async let` fetching `/api/review/study-stats`; on success store on `studyStats`; on failure leave existing data intact.
+
+3. **View** `fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift`:
+   - Add a `streakBanner` view rendered above `statsRow` when `viewModel.studyStats?.totalAnswered ?? 0 > 0`:
+     ```
+     🔥  7 day streak     · best 14
+     ```
+     Use `.ultraThinMaterial` background + rounded rectangle to match other cards.
+   - Modify `statsRow` so the three pills become "Total answered" / "Today" / "Best streak" (using `studyStats` values) when `studyStats` is present; otherwise keep the existing Total/Today/Decks fallback.
+   - Existing `stateBar` and `deckSection` stay unchanged.
+
+## Verification
+
+After all three tracks land:
+
+1. `dotnet test fasolt.Tests` — all green
+2. `dotnet build` — no warnings introduced
+3. `cd fasolt.client && npx tsc --noEmit && npm run build` — clean
+4. iOS: `xcodebuild -project fasolt.ios/Fasolt.xcodeproj -scheme Fasolt -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` (or similar) — succeeds
+5. Manual: `make dev`, log in as dev user, rate a card on web, refresh — see numbers move. Same on iOS sim.

--- a/docs/superpowers/specs/2026-05-14-motivational-study-stats-design.md
+++ b/docs/superpowers/specs/2026-05-14-motivational-study-stats-design.md
@@ -1,0 +1,159 @@
+# Motivational study stats — Design
+
+GitHub issue: #150
+
+## Goal
+
+Show four lightweight motivational stats on the dashboard (web + iOS):
+
+1. **Current streak** — consecutive study days, allowing no-due rest days
+2. **Best streak** — longest streak ever
+3. **Total answered cards** — cumulative count of all ratings the user has submitted
+4. **Cards answered today** — count of ratings submitted today (user's local day)
+
+Out of scope: badges, leaderboards, freezes, daily-goal config, calendar views.
+
+## What we have today
+
+- `Card.LastReviewedAt` records the *last* review per card — not enough for streak history or "total answered".
+- `ReviewService.RateCard` mutates the card and saves. There is no review log.
+- `OverviewService` exposes basic counters. `ReviewService.GetStats` exposes `dueCount / totalCards / studiedToday` (today = unique cards with `LastReviewedAt >= UTC midnight`, ignoring TZ).
+- User day boundary is configurable via `AppUser.TimeZone` and `AppUser.DayStartHour` (see `DueTimeRounder`).
+
+## Approach
+
+### Append-only review log
+
+Add a new entity `ReviewLog` capturing every rate event:
+
+```csharp
+public class ReviewLog
+{
+    public long Id { get; set; }                // bigserial
+    public string UserId { get; set; }
+    public Guid CardId { get; set; }
+    public string Rating { get; set; }          // again|hard|good|easy
+    public DateTimeOffset ReviewedAt { get; set; }
+    public DateTimeOffset? ScheduledDueAfter { get; set; }  // new due assigned by FSRS after this rating
+    public string StateAfter { get; set; }      // "learning"|"review"|"relearning"
+}
+```
+
+Indexes: `(UserId, ReviewedAt)`, `(UserId, CardId, ReviewedAt)`.
+
+`ReviewService.RateCard` writes one row per call before `SaveChangesAsync`. Skipped cards are not rated → not logged (matches "skipped cards do not count").
+
+We do **not** backfill historical reviews — the log starts when this feature ships. The "total answered" and streak start from zero/empty for existing users. That's a deliberate simplification, documented in the PR description.
+
+### Streak semantics
+
+A **study day** is a user-tz day with at least one `ReviewLog` row.
+A **due day** is a user-tz day where the user had ≥1 card scheduled to be due at any point during that day.
+
+Approximating "due day" without historical snapshots: a day X is a due day iff there exists a card such that, at the end of day X (user tz), the card existed and its latest scheduled-due was ≤ end-of-day X. We reconstruct "latest scheduled due as of T" as:
+
+- The most recent `ReviewLog.ScheduledDueAfter` with `ReviewedAt <= T`, or
+- If no log entries exist for the card before T: the card's initial due (treated as `CreatedAt` — i.e., new cards are due immediately).
+
+In SQL: for each candidate day, `EXISTS` query against cards joined with their latest-before-T log row.
+
+### Current streak
+
+Walk back day-by-day from today (user tz), bounded by the user's earliest card-creation day or 365 days, whichever is smaller:
+
+```
+streak = 0
+cursor = today
+if today is a study day:
+    streak = 1
+cursor -= 1 day
+while cursor >= earliest:
+    if cursor is a study day:        streak += 1
+    elif cursor is a due day:        break        # missed
+    else:                            pass         # rest day, preserved
+    cursor -= 1 day
+return streak
+```
+
+Today is special-cased: if the user hasn't reviewed yet but the day isn't over, we don't break the streak — we just don't count today.
+
+### Best streak
+
+Pre-compute on first request (and update on every rate event in-memory). Cached on `AppUser.BestStreak` (new column, default 0). On each rate event:
+
+1. Recompute current streak after the new log row.
+2. If `current > user.BestStreak`, set `BestStreak = current`.
+
+For users who already have history when this ships, `BestStreak` starts at 0 and grows with their current streak going forward.
+
+### Totals
+
+- `totalAnswered` = `COUNT(*)` on `ReviewLog` filtered by user.
+- `answeredToday` = `COUNT(*)` on `ReviewLog` where `ReviewedAt` falls within the current user-tz day.
+
+## API
+
+New endpoint:
+
+```
+GET /api/review/study-stats
+```
+
+Response:
+
+```json
+{
+  "currentStreak": 7,
+  "bestStreak": 14,
+  "totalAnswered": 482,
+  "answeredToday": 12
+}
+```
+
+Owned by a new service `StudyStatsService` (constructor: `AppDbContext`, `TimeProvider`). Endpoint lives in `ReviewEndpoints.cs` (consistent with the other study-related endpoints).
+
+## Frontend — Web
+
+`StudyView.vue` already has a stats row (`{{ totalCards }} total • {{ studiedToday }} today`). Replace with a four-stat row:
+
+```
+🔥 7 day streak     482 total answered     12 today     Best: 14
+```
+
+Implementation:
+
+- Add `StudyStats` type and `apiFetch('/review/study-stats')` call.
+- Fetch alongside existing stats in `onMounted`.
+- Render under the existing "due" hero. Streak shown with a flame emoji or `🔥` (kept text-only to match existing visual restraint).
+
+`fasolt.client/src/api/client.ts` is the path. `fasolt.client/src/types` gets a new `StudyStats` type.
+
+## Frontend — iOS
+
+`DashboardView.swift` already has a `statsRow` with Total / Today / Decks. Replace with a streak-centric layout:
+
+```
+[ 🔥 7 day streak ]   <- prominent badge above stats row
+[Total 482]  [Today 12]  [Best 14]   <- modified statPills
+```
+
+Implementation:
+
+- Add `StudyStatsDTO` to `APIModels.swift`.
+- Add a `studyStats` field to `DashboardViewModel`, load it in `loadStats()` alongside the other parallel fetches.
+- Add a streak banner above the existing stats row in `DashboardView`.
+- Replace `totalCards/studiedToday/totalDecks` pills with `totalAnswered/answeredToday/bestStreak`. We keep `totalCards` for the empty-state check elsewhere in the view.
+
+We do **not** drop `Total cards` from the iOS dashboard immediately — the existing stateBar still needs `totalCards` for proportions. We instead keep the existing `OverviewDTO` data and just add the new streak banner + replace the three stat pills.
+
+## Testing
+
+- Unit tests for `StudyStatsService` covering: empty history, streak with no rest days, streak with rest days, broken streak, today not yet reviewed, day-boundary TZ math.
+- Integration test: hit `/api/review/study-stats`, rate a card, hit again, verify counts move.
+- Manual: log in as `dev@fasolt.local`, review demo deck cards, refresh dashboard on web and iOS simulator, confirm numbers.
+
+## Rollout
+
+- Single PR per CLAUDE.md guidance.
+- One EF migration (`AddReviewLogAndBestStreak`).
+- No data backfill. Existing users start from zero for streak/total — acceptable.

--- a/fasolt.Server/Api/Endpoints/ReviewEndpoints.cs
+++ b/fasolt.Server/Api/Endpoints/ReviewEndpoints.cs
@@ -15,6 +15,7 @@ public static class ReviewEndpoints
         group.MapPost("/rate", RateCard);
         group.MapGet("/stats", GetStats);
         group.MapGet("/overview", GetOverview);
+        group.MapGet("/study-stats", GetStudyStats);
     }
 
     private static async Task<IResult> GetDueCards(
@@ -67,5 +68,15 @@ public static class ReviewEndpoints
 
         var overview = await overviewService.GetOverview(user.Id);
         return Results.Ok(overview);
+    }
+
+    private static async Task<IResult> GetStudyStats(
+        ClaimsPrincipal principal, UserManager<AppUser> userManager, StudyStatsService studyStatsService)
+    {
+        var user = await userManager.GetUserAsync(principal);
+        if (user is null) return Results.Unauthorized();
+
+        var stats = await studyStatsService.GetStats(user.Id);
+        return Results.Ok(stats);
     }
 }

--- a/fasolt.Server/Application/Dtos/StudyStatsDto.cs
+++ b/fasolt.Server/Application/Dtos/StudyStatsDto.cs
@@ -1,0 +1,3 @@
+namespace Fasolt.Server.Application.Dtos;
+
+public record StudyStatsDto(int CurrentStreak, int BestStreak, int TotalAnswered, int AnsweredToday);

--- a/fasolt.Server/Application/Services/ReviewService.cs
+++ b/fasolt.Server/Application/Services/ReviewService.cs
@@ -10,7 +10,7 @@ using FsrsCard = FSRS.Core.Models.Card;
 
 namespace Fasolt.Server.Application.Services;
 
-public class ReviewService(AppDbContext db, TimeProvider timeProvider)
+public class ReviewService(AppDbContext db, TimeProvider timeProvider, StudyStatsService studyStatsService)
 {
     private static readonly Dictionary<string, Rating> ValidRatings = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -110,7 +110,19 @@ public class ReviewService(AppDbContext db, TimeProvider timeProvider)
         card.DueAt = new DateTimeOffset(roundedDue, TimeSpan.Zero);
         card.LastReviewedAt = timeProvider.GetUtcNow();
 
+        db.ReviewLogs.Add(new ReviewLog
+        {
+            UserId = userId,
+            CardId = card.Id,
+            Rating = request.Rating.ToLowerInvariant(),
+            ReviewedAt = timeProvider.GetUtcNow(),
+            ScheduledDueAfter = card.DueAt,
+            StateAfter = card.State,
+        });
+
         await db.SaveChangesAsync();
+        await studyStatsService.UpdateBestStreakIfNeeded(userId);
+
         return new RateCardResponse(card.PublicId, card.Stability, card.Difficulty, card.DueAt, card.State);
     }
 

--- a/fasolt.Server/Application/Services/StudyStatsService.cs
+++ b/fasolt.Server/Application/Services/StudyStatsService.cs
@@ -1,0 +1,153 @@
+using Microsoft.EntityFrameworkCore;
+using Fasolt.Server.Application.Dtos;
+using Fasolt.Server.Infrastructure.Data;
+
+namespace Fasolt.Server.Application.Services;
+
+public class StudyStatsService(AppDbContext db, TimeProvider timeProvider)
+{
+    public async Task<StudyStatsDto> GetStats(string userId)
+    {
+        var user = await db.Users.FirstAsync(u => u.Id == userId);
+        var tz = DueTimeRounder.ResolveTimeZone(user.TimeZone);
+        var dayStartHour = user.DayStartHour ?? DueTimeRounder.DefaultDayStartHour;
+
+        var now = timeProvider.GetUtcNow();
+        var (todayStart, todayEnd) = GetDayBoundaries(now, tz, dayStartHour);
+
+        var totalAnswered = await db.ReviewLogs.CountAsync(r => r.UserId == userId);
+        var answeredToday = await db.ReviewLogs.CountAsync(r =>
+            r.UserId == userId && r.ReviewedAt >= todayStart && r.ReviewedAt < todayEnd);
+
+        var currentStreak = await ComputeCurrentStreak(userId, now, tz, dayStartHour);
+        var bestStreak = Math.Max(user.BestStreak, currentStreak);
+
+        return new StudyStatsDto(currentStreak, bestStreak, totalAnswered, answeredToday);
+    }
+
+    public async Task UpdateBestStreakIfNeeded(string userId)
+    {
+        var user = await db.Users.FirstAsync(u => u.Id == userId);
+        var tz = DueTimeRounder.ResolveTimeZone(user.TimeZone);
+        var dayStartHour = user.DayStartHour ?? DueTimeRounder.DefaultDayStartHour;
+        var now = timeProvider.GetUtcNow();
+
+        var currentStreak = await ComputeCurrentStreak(userId, now, tz, dayStartHour);
+        if (currentStreak > user.BestStreak)
+        {
+            user.BestStreak = currentStreak;
+            await db.SaveChangesAsync();
+        }
+    }
+
+    private async Task<int> ComputeCurrentStreak(string userId, DateTimeOffset now, TimeZoneInfo tz, int dayStartHour)
+    {
+        // Short-circuit: if user has no cards at all, return 0
+        var earliestCardCreatedAt = await db.Cards
+            .Where(c => c.UserId == userId)
+            .Select(c => (DateTimeOffset?)c.CreatedAt)
+            .MinAsync();
+
+        if (earliestCardCreatedAt is null)
+            return 0;
+
+        // Pre-load the set of distinct study-day start boundaries (UTC) the user has reviewed on
+        // We fetch all ReviewedAt timestamps and bucket them client-side for correctness with custom day boundaries
+        var allReviewedAts = await db.ReviewLogs
+            .Where(r => r.UserId == userId)
+            .Select(r => r.ReviewedAt)
+            .ToListAsync();
+
+        var studyDayStarts = new HashSet<DateTimeOffset>(
+            allReviewedAts.Select(r => GetDayBoundaries(r, tz, dayStartHour).Start));
+
+        var (todayStart, _) = GetDayBoundaries(now, tz, dayStartHour);
+        var (earliestStart, _) = GetDayBoundaries(earliestCardCreatedAt.Value, tz, dayStartHour);
+
+        // Bound: at most 365 days back, and not before earliest card creation day
+        var cutoff = todayStart.AddDays(-365);
+        if (earliestStart > cutoff)
+            cutoff = earliestStart;
+
+        var streak = 0;
+
+        // Today is special: if reviewed today, count it; then start walking from yesterday.
+        // If not reviewed today, we don't break the streak — just start walking from yesterday.
+        if (studyDayStarts.Contains(todayStart))
+            streak = 1;
+
+        var cursor = todayStart.AddDays(-1);
+
+        while (cursor >= cutoff)
+        {
+            if (studyDayStarts.Contains(cursor))
+            {
+                streak++;
+            }
+            else
+            {
+                // No review on this day — check if it was a due day (missed = streak breaks)
+                var isDue = await IsDueDay(userId, cursor, tz, dayStartHour);
+                if (isDue)
+                    break;
+                // else: rest day (no due cards), streak preserved
+            }
+
+            cursor = cursor.AddDays(-1);
+        }
+
+        return streak;
+    }
+
+    private async Task<bool> IsDueDay(string userId, DateTimeOffset dayStart, TimeZoneInfo tz, int dayStartHour)
+    {
+        var (_, dayEnd) = (dayStart, dayStart.AddDays(1));
+        // dayEnd is the exclusive end; for the "due as of end of day" check we use dayStart.AddDays(1)
+        // which is the start of next day = end of this day
+        var dayEndInclusive = dayStart.AddDays(1);
+
+        // A day is a "due day" if there exists a card created on/before day-end
+        // whose latest-known scheduled-due as of day-end <= day-end.
+        // "latest scheduled due as of T" = MAX(ScheduledDueAfter) from ReviewLogs where ReviewedAt <= T,
+        // or Card.CreatedAt if no such log row.
+
+        // We check: does any card exist where:
+        //   card.CreatedAt <= dayEnd AND
+        //   (the max ScheduledDueAfter from logs with ReviewedAt <= dayEnd, or card.CreatedAt if none) <= dayEnd
+
+        // Implemented as: EXISTS a card c where:
+        //   c.UserId == userId
+        //   c.CreatedAt <= dayEndInclusive
+        //   effective_due(c, dayEndInclusive) <= dayEndInclusive
+        //
+        // effective_due = MAX log.ScheduledDueAfter (where log.CardId = c.Id AND log.ReviewedAt <= dayEndInclusive)
+        //                 OR c.CreatedAt if no such log
+
+        return await db.Cards
+            .Where(c => c.UserId == userId && c.CreatedAt <= dayEndInclusive)
+            .AnyAsync(c =>
+                (db.ReviewLogs
+                    .Where(l => l.CardId == c.Id && l.ReviewedAt <= dayEndInclusive && l.ScheduledDueAfter != null)
+                    .Max(l => (DateTimeOffset?)l.ScheduledDueAfter) ?? c.CreatedAt) <= dayEndInclusive);
+    }
+
+    private static (DateTimeOffset Start, DateTimeOffset End) GetDayBoundaries(
+        DateTimeOffset utcTime, TimeZoneInfo tz, int dayStartHour)
+    {
+        var localTime = TimeZoneInfo.ConvertTime(utcTime, tz);
+        var localDate = localTime.TimeOfDay < TimeSpan.FromHours(dayStartHour)
+            ? localTime.Date.AddDays(-1)
+            : localTime.Date;
+
+        var localStart = DateTime.SpecifyKind(localDate.AddHours(dayStartHour), DateTimeKind.Unspecified);
+
+        // Handle DST gaps
+        while (tz.IsInvalidTime(localStart))
+            localStart = localStart.AddHours(1);
+
+        var startUtc = new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(localStart, tz));
+        var endUtc = startUtc.AddDays(1);
+
+        return (startUtc, endUtc);
+    }
+}

--- a/fasolt.Server/Application/Services/StudyStatsService.cs
+++ b/fasolt.Server/Application/Services/StudyStatsService.cs
@@ -51,16 +51,6 @@ public class StudyStatsService(AppDbContext db, TimeProvider timeProvider)
         if (earliestCardCreatedAt is null)
             return 0;
 
-        // Pre-load the set of distinct study-day start boundaries (UTC) the user has reviewed on
-        // We fetch all ReviewedAt timestamps and bucket them client-side for correctness with custom day boundaries
-        var allReviewedAts = await db.ReviewLogs
-            .Where(r => r.UserId == userId)
-            .Select(r => r.ReviewedAt)
-            .ToListAsync();
-
-        var studyDayStarts = new HashSet<DateTimeOffset>(
-            allReviewedAts.Select(r => GetDayBoundaries(r, tz, dayStartHour).Start));
-
         var (todayStart, _) = GetDayBoundaries(now, tz, dayStartHour);
         var (earliestStart, _) = GetDayBoundaries(earliestCardCreatedAt.Value, tz, dayStartHour);
 
@@ -68,6 +58,21 @@ public class StudyStatsService(AppDbContext db, TimeProvider timeProvider)
         var cutoff = todayStart.AddDays(-365);
         if (earliestStart > cutoff)
             cutoff = earliestStart;
+
+        // Pre-load study-day boundaries from reviews in the walk window only.
+        // Bucketing is done client-side so custom per-user day boundaries are respected.
+        var windowStart = now.AddDays(-366);
+        var windowReviewedAts = await db.ReviewLogs
+            .Where(r => r.UserId == userId && r.ReviewedAt >= windowStart)
+            .Select(r => r.ReviewedAt)
+            .ToListAsync();
+
+        var studyDayStarts = new HashSet<DateTimeOffset>(
+            windowReviewedAts.Select(r => GetDayBoundaries(r, tz, dayStartHour).Start));
+
+        // Precompute the set of "due days" in the walk window with a single load,
+        // instead of a per-day SQL round-trip (avoids N+1 in the gap walk).
+        var dueDayStarts = await ComputeDueDayStarts(userId, cutoff, todayStart, tz, dayStartHour);
 
         var streak = 0;
 
@@ -84,14 +89,11 @@ public class StudyStatsService(AppDbContext db, TimeProvider timeProvider)
             {
                 streak++;
             }
-            else
+            else if (dueDayStarts.Contains(cursor))
             {
-                // No review on this day — check if it was a due day (missed = streak breaks)
-                var isDue = await IsDueDay(userId, cursor, tz, dayStartHour);
-                if (isDue)
-                    break;
-                // else: rest day (no due cards), streak preserved
+                break;
             }
+            // else: rest day (no due cards), streak preserved
 
             cursor = cursor.AddDays(-1);
         }
@@ -99,36 +101,75 @@ public class StudyStatsService(AppDbContext db, TimeProvider timeProvider)
         return streak;
     }
 
-    private async Task<bool> IsDueDay(string userId, DateTimeOffset dayStart, TimeZoneInfo tz, int dayStartHour)
+    private async Task<HashSet<DateTimeOffset>> ComputeDueDayStarts(
+        string userId, DateTimeOffset cutoff, DateTimeOffset todayStart, TimeZoneInfo tz, int dayStartHour)
     {
-        var (_, dayEnd) = (dayStart, dayStart.AddDays(1));
-        // dayEnd is the exclusive end; for the "due as of end of day" check we use dayStart.AddDays(1)
-        // which is the start of next day = end of this day
-        var dayEndInclusive = dayStart.AddDays(1);
+        var todayEnd = todayStart.AddDays(1);
 
-        // A day is a "due day" if there exists a card created on/before day-end
-        // whose latest-known scheduled-due as of day-end <= day-end.
-        // "latest scheduled due as of T" = MAX(ScheduledDueAfter) from ReviewLogs where ReviewedAt <= T,
-        // or Card.CreatedAt if no such log row.
+        var cards = await db.Cards
+            .Where(c => c.UserId == userId && c.CreatedAt <= todayEnd)
+            .Select(c => new { c.Id, c.CreatedAt })
+            .ToListAsync();
 
-        // We check: does any card exist where:
-        //   card.CreatedAt <= dayEnd AND
-        //   (the max ScheduledDueAfter from logs with ReviewedAt <= dayEnd, or card.CreatedAt if none) <= dayEnd
+        if (cards.Count == 0)
+            return new HashSet<DateTimeOffset>();
 
-        // Implemented as: EXISTS a card c where:
-        //   c.UserId == userId
-        //   c.CreatedAt <= dayEndInclusive
-        //   effective_due(c, dayEndInclusive) <= dayEndInclusive
-        //
-        // effective_due = MAX log.ScheduledDueAfter (where log.CardId = c.Id AND log.ReviewedAt <= dayEndInclusive)
-        //                 OR c.CreatedAt if no such log
+        // For each card with logs before the walk window, fetch MAX(ScheduledDueAfter)
+        // to initialise effective-due at cutoff (matches original "MAX over all eligible logs" semantics).
+        var preWindowMaxByCard = await db.ReviewLogs
+            .Where(r => r.UserId == userId && r.ReviewedAt < cutoff && r.ScheduledDueAfter != null)
+            .GroupBy(r => r.CardId)
+            .Select(g => new { CardId = g.Key, MaxDue = g.Max(x => x.ScheduledDueAfter) })
+            .ToDictionaryAsync(x => x.CardId, x => x.MaxDue!.Value);
 
-        return await db.Cards
-            .Where(c => c.UserId == userId && c.CreatedAt <= dayEndInclusive)
-            .AnyAsync(c =>
-                (db.ReviewLogs
-                    .Where(l => l.CardId == c.Id && l.ReviewedAt <= dayEndInclusive && l.ScheduledDueAfter != null)
-                    .Max(l => (DateTimeOffset?)l.ScheduledDueAfter) ?? c.CreatedAt) <= dayEndInclusive);
+        var inWindowLogs = await db.ReviewLogs
+            .Where(r => r.UserId == userId && r.ReviewedAt >= cutoff && r.ScheduledDueAfter != null)
+            .OrderBy(r => r.ReviewedAt)
+            .Select(r => new { r.CardId, r.ReviewedAt, ScheduledDueAfter = r.ScheduledDueAfter!.Value })
+            .ToListAsync();
+
+        var logsByCard = inWindowLogs
+            .GroupBy(l => l.CardId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var dueDayStarts = new HashSet<DateTimeOffset>();
+
+        foreach (var card in cards)
+        {
+            var cardCreatedDay = GetDayBoundaries(card.CreatedAt, tz, dayStartHour).Start;
+            var startCursor = cardCreatedDay < cutoff ? cutoff : cardCreatedDay;
+            if (startCursor >= todayStart)
+                continue;
+
+            // Initial effective-due at startCursor: MAX of pre-window scheduled-dues, or CreatedAt if none.
+            // (Cards created within the window have no pre-window logs, so they start at CreatedAt.)
+            var effectiveDue = preWindowMaxByCard.TryGetValue(card.Id, out var preMax)
+                ? preMax
+                : card.CreatedAt;
+
+            var logs = logsByCard.TryGetValue(card.Id, out var l) ? l : null;
+            var logIdx = 0;
+
+            for (var cursor = startCursor; cursor < todayStart; cursor = cursor.AddDays(1))
+            {
+                var dayEnd = cursor.AddDays(1);
+
+                if (logs is not null)
+                {
+                    while (logIdx < logs.Count && logs[logIdx].ReviewedAt < dayEnd)
+                    {
+                        if (logs[logIdx].ScheduledDueAfter > effectiveDue)
+                            effectiveDue = logs[logIdx].ScheduledDueAfter;
+                        logIdx++;
+                    }
+                }
+
+                if (effectiveDue <= dayEnd)
+                    dueDayStarts.Add(cursor);
+            }
+        }
+
+        return dueDayStarts;
     }
 
     private static (DateTimeOffset Start, DateTimeOffset End) GetDayBoundaries(

--- a/fasolt.Server/Domain/Entities/AppUser.cs
+++ b/fasolt.Server/Domain/Entities/AppUser.cs
@@ -12,4 +12,5 @@ public class AppUser : IdentityUser
     public string? TimeZone { get; set; }
     public string? ExternalProvider { get; set; }
     public string? ExternalProviderId { get; set; }
+    public int BestStreak { get; set; } = 0;
 }

--- a/fasolt.Server/Domain/Entities/ReviewLog.cs
+++ b/fasolt.Server/Domain/Entities/ReviewLog.cs
@@ -1,0 +1,14 @@
+namespace Fasolt.Server.Domain.Entities;
+
+public class ReviewLog
+{
+    public long Id { get; set; }
+    public string UserId { get; set; } = default!;
+    public AppUser User { get; set; } = default!;
+    public Guid CardId { get; set; }
+    public Card Card { get; set; } = default!;
+    public string Rating { get; set; } = default!;
+    public DateTimeOffset ReviewedAt { get; set; }
+    public DateTimeOffset? ScheduledDueAfter { get; set; }
+    public string StateAfter { get; set; } = default!;
+}

--- a/fasolt.Server/Infrastructure/Data/AppDbContext.cs
+++ b/fasolt.Server/Infrastructure/Data/AppDbContext.cs
@@ -12,6 +12,7 @@ public class AppDbContext : IdentityDbContext<AppUser>, IDataProtectionKeyContex
     }
 
     public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
+    public DbSet<ReviewLog> ReviewLogs => Set<ReviewLog>();
     public DbSet<Card> Cards => Set<Card>();
     public DbSet<Deck> Decks => Set<Deck>();
     public DbSet<DeckCard> DeckCards => Set<DeckCard>();
@@ -102,6 +103,17 @@ public class AppDbContext : IdentityDbContext<AppUser>, IDataProtectionKeyContex
             entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Cascade);
         });
 
+        builder.Entity<ReviewLog>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Rating).HasMaxLength(20).IsRequired();
+            entity.Property(e => e.StateAfter).HasMaxLength(20).IsRequired();
+            entity.HasIndex(e => new { e.UserId, e.ReviewedAt });
+            entity.HasIndex(e => new { e.CardId, e.ReviewedAt });
+            entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.Card).WithMany().HasForeignKey(e => e.CardId).OnDelete(DeleteBehavior.Cascade);
+        });
+
         builder.Entity<AppUser>(entity =>
         {
             entity.Property(e => e.NotificationIntervalHours).HasDefaultValue(8);
@@ -111,6 +123,7 @@ public class AppDbContext : IdentityDbContext<AppUser>, IDataProtectionKeyContex
             entity.Property(e => e.TimeZone).HasMaxLength(64);
             entity.Property(e => e.ExternalProvider).HasMaxLength(50);
             entity.Property(e => e.ExternalProviderId).HasMaxLength(255);
+            entity.Property(e => e.BestStreak).HasDefaultValue(0);
             entity.HasIndex(e => new { e.ExternalProvider, e.ExternalProviderId })
                 .IsUnique()
                 .HasFilter("\"ExternalProvider\" IS NOT NULL");

--- a/fasolt.Server/Infrastructure/Data/Migrations/20260514111611_AddReviewLogAndBestStreak.Designer.cs
+++ b/fasolt.Server/Infrastructure/Data/Migrations/20260514111611_AddReviewLogAndBestStreak.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fasolt.Server.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Fasolt.Server.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514111611_AddReviewLogAndBestStreak")]
+    partial class AddReviewLogAndBestStreak
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/fasolt.Server/Infrastructure/Data/Migrations/20260514111611_AddReviewLogAndBestStreak.cs
+++ b/fasolt.Server/Infrastructure/Data/Migrations/20260514111611_AddReviewLogAndBestStreak.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Fasolt.Server.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReviewLogAndBestStreak : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BestStreak",
+                table: "AspNetUsers",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "ReviewLogs",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    CardId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Rating = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    ReviewedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ScheduledDueAfter = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    StateAfter = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReviewLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ReviewLogs_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ReviewLogs_Cards_CardId",
+                        column: x => x.CardId,
+                        principalTable: "Cards",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReviewLogs_CardId_ReviewedAt",
+                table: "ReviewLogs",
+                columns: new[] { "CardId", "ReviewedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReviewLogs_UserId_ReviewedAt",
+                table: "ReviewLogs",
+                columns: new[] { "UserId", "ReviewedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReviewLogs");
+
+            migrationBuilder.DropColumn(
+                name: "BestStreak",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/fasolt.Server/Program.cs
+++ b/fasolt.Server/Program.cs
@@ -335,6 +335,7 @@ builder.Services.AddScoped<AdminService>();
 builder.Services.AddScoped<SourceService>();
 builder.Services.AddScoped<OverviewService>();
 builder.Services.AddScoped<ReviewService>();
+builder.Services.AddScoped<StudyStatsService>();
 builder.Services.AddScoped<DeviceTokenService>();
 builder.Services.AddScoped<SchedulingSettingsService>();
 builder.Services.AddScoped<DeckSnapshotService>();

--- a/fasolt.Tests/ReviewServiceTests.cs
+++ b/fasolt.Tests/ReviewServiceTests.cs
@@ -18,7 +18,7 @@ public class ReviewServiceTests : IAsyncLifetime
     public async Task DisposeAsync() => await _db.DisposeAsync();
 
     private ReviewService CreateService(Server.Infrastructure.Data.AppDbContext db)
-        => new(db, _time);
+        => new(db, _time, new StudyStatsService(db, _time));
 
     private async Task<string> CreateCard(Server.Infrastructure.Data.AppDbContext db, string front, string back)
     {

--- a/fasolt.Tests/StudyStatsServiceTests.cs
+++ b/fasolt.Tests/StudyStatsServiceTests.cs
@@ -1,0 +1,217 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using Fasolt.Server.Application.Dtos;
+using Fasolt.Server.Application.Services;
+using Fasolt.Server.Domain.Entities;
+using Fasolt.Server.Infrastructure;
+using Fasolt.Tests.Helpers;
+
+namespace Fasolt.Tests;
+
+public class StudyStatsServiceTests : IAsyncLifetime
+{
+    private readonly TestDb _db = new();
+    // Start on a Monday at 05:00 UTC so day-start (04:00 UTC) has already passed
+    private readonly FakeTimeProvider _time = new(new DateTimeOffset(2025, 6, 2, 5, 0, 0, TimeSpan.Zero));
+
+    private string UserId => _db.UserId;
+
+    public async Task InitializeAsync() => await _db.InitializeAsync();
+    public async Task DisposeAsync() => await _db.DisposeAsync();
+
+    private StudyStatsService CreateStatsService(Server.Infrastructure.Data.AppDbContext db)
+        => new(db, _time);
+
+    private ReviewService CreateReviewService(Server.Infrastructure.Data.AppDbContext db)
+        => new(db, _time, new StudyStatsService(db, _time));
+
+    // Creates a card with CreatedAt set to the current fake-time clock so the
+    // card exists "as of now" in tests that manipulate _time.
+    private async Task<string> CreateCardAt(Server.Infrastructure.Data.AppDbContext db, DateTimeOffset createdAt,
+        string front = "Q?", string back = "A.")
+    {
+        var card = new Card
+        {
+            Id = Guid.NewGuid(),
+            PublicId = NanoIdGenerator.New(),
+            UserId = UserId,
+            Front = front,
+            Back = back,
+            CreatedAt = createdAt,
+        };
+        db.Cards.Add(card);
+        await db.SaveChangesAsync();
+        return card.PublicId;
+    }
+
+    // --- Empty account ---
+
+    [Fact]
+    public async Task Empty_ReturnsAllZeros()
+    {
+        await using var db = _db.CreateDbContext();
+        var svc = CreateStatsService(db);
+
+        var stats = await svc.GetStats(UserId);
+
+        stats.CurrentStreak.Should().Be(0);
+        stats.BestStreak.Should().Be(0);
+        stats.TotalAnswered.Should().Be(0);
+        stats.AnsweredToday.Should().Be(0);
+    }
+
+    // --- Single review today ---
+
+    [Fact]
+    public async Task SingleReviewToday_ReturnsCorrectStats()
+    {
+        await using var db = _db.CreateDbContext();
+        var cardId = await CreateCardAt(db, _time.GetUtcNow().AddHours(-1));
+        var reviewSvc = CreateReviewService(db);
+        await reviewSvc.RateCard(UserId, new RateCardRequest(cardId, "good"));
+
+        var statsSvc = CreateStatsService(db);
+        var stats = await statsSvc.GetStats(UserId);
+
+        stats.CurrentStreak.Should().Be(1);
+        stats.BestStreak.Should().Be(1);
+        stats.TotalAnswered.Should().Be(1);
+        stats.AnsweredToday.Should().Be(1);
+    }
+
+    // --- Two consecutive days ---
+
+    [Fact]
+    public async Task TwoConsecutiveDays_Streak2()
+    {
+        await using var db = _db.CreateDbContext();
+
+        // Day 1: create card and review
+        var day1 = _time.GetUtcNow(); // 2025-06-02 05:00 UTC
+        var cardId = await CreateCardAt(db, day1.AddHours(-1));
+        var reviewSvc = CreateReviewService(db);
+        await reviewSvc.RateCard(UserId, new RateCardRequest(cardId, "good"));
+
+        // Day 2: advance time by 1 day, create another card, review it
+        _time.SetUtcNow(day1.AddDays(1));
+        var card2Id = await CreateCardAt(db, _time.GetUtcNow().AddMinutes(-10));
+        await reviewSvc.RateCard(UserId, new RateCardRequest(card2Id, "good"));
+
+        var statsSvc = CreateStatsService(db);
+        var stats = await statsSvc.GetStats(UserId);
+
+        stats.CurrentStreak.Should().Be(2);
+        stats.TotalAnswered.Should().Be(2);
+        stats.AnsweredToday.Should().Be(1);
+    }
+
+    // --- Gap day with no due cards (rest day) ---
+    // Rate card1 "easy" on day 1 so it's due far in the future.
+    // Skip day 2 entirely (no due cards).
+    // Create card2 on day 3 and review it.
+    // Streak should be 2 (day 1 + day 3; day 2 is a rest day because no cards were due).
+
+    [Fact]
+    public async Task GapDayWithNoDueCards_StreakPreserved()
+    {
+        await using var db = _db.CreateDbContext();
+        var reviewSvc = CreateReviewService(db);
+
+        // Day 1: review card1 "easy" -> scheduled far ahead
+        var day1 = _time.GetUtcNow();
+        var card1Id = await CreateCardAt(db, day1.AddHours(-1));
+        var result1 = await reviewSvc.RateCard(UserId, new RateCardRequest(card1Id, "easy"));
+        result1.Should().NotBeNull();
+        // Card1 is now due far in the future (easy rating), well past day 2
+
+        // Day 2: no reviews (skip)
+        // Day 3: create card2 and review it
+        _time.SetUtcNow(day1.AddDays(2));
+        var card2Id = await CreateCardAt(db, _time.GetUtcNow().AddMinutes(-5));
+        await reviewSvc.RateCard(UserId, new RateCardRequest(card2Id, "good"));
+
+        var statsSvc = CreateStatsService(db);
+        var stats = await statsSvc.GetStats(UserId);
+
+        // Day 2 had no due cards (card1 was scheduled far ahead, card2 didn't exist yet)
+        // so it's a rest day and streak is preserved: day1 + day3 = 2
+        stats.CurrentStreak.Should().Be(2);
+        stats.TotalAnswered.Should().Be(2);
+    }
+
+    // --- Gap day WITH due cards but no review (streak breaks) ---
+    // card1 created day 1, rated good (short interval).
+    // card2 created day 1, never reviewed through day 2.
+    // On day 3, rate card2. Since day 2 had a due card (card2), streak resets to 1.
+
+    [Fact]
+    public async Task GapDayWithDueCards_StreakBreaks()
+    {
+        await using var db = _db.CreateDbContext();
+        var reviewSvc = CreateReviewService(db);
+
+        var day1 = _time.GetUtcNow();
+
+        // Create card1 and rate it on day 1 (good → scheduled in future)
+        var card1Id = await CreateCardAt(db, day1.AddHours(-1), "Card1?", "Card1.");
+        await reviewSvc.RateCard(UserId, new RateCardRequest(card1Id, "good"));
+
+        // Create card2 on day 1 but do NOT review it
+        var card2Id = await CreateCardAt(db, day1.AddMinutes(-30), "Card2?", "Card2.");
+
+        // Jump to day 3 and review card2 (it was due since day 1, so day 2 is a "due day")
+        _time.SetUtcNow(day1.AddDays(2));
+        await reviewSvc.RateCard(UserId, new RateCardRequest(card2Id, "good"));
+
+        var statsSvc = CreateStatsService(db);
+        var stats = await statsSvc.GetStats(UserId);
+
+        // card2 was due on day 2 and was not reviewed → streak breaks → current streak = 1
+        stats.CurrentStreak.Should().Be(1);
+    }
+
+    // --- BestStreak persists after current streak resets ---
+
+    [Fact]
+    public async Task BestStreak_PersistsAfterCurrentStreakResets()
+    {
+        await using var db = _db.CreateDbContext();
+        var reviewSvc = CreateReviewService(db);
+        var day1 = _time.GetUtcNow();
+
+        // Build a 3-day streak: day1, day2, day3
+        for (var i = 0; i < 3; i++)
+        {
+            _time.SetUtcNow(day1.AddDays(i));
+            var cardId = await CreateCardAt(db, _time.GetUtcNow().AddMinutes(-5));
+            await reviewSvc.RateCard(UserId, new RateCardRequest(cardId, "easy"));
+        }
+
+        // Verify streak is 3 after day 3
+        {
+            var statsSvc = CreateStatsService(db);
+            var stats = await statsSvc.GetStats(UserId);
+            stats.CurrentStreak.Should().Be(3);
+            stats.BestStreak.Should().Be(3);
+        }
+
+        // Day 5 (break day 4) — create a new card on day 4 without reviewing, then review on day 5
+        // On day 4 a new card was due (created on day 4 = immediately due); day 4 had no review → streak breaks
+        _time.SetUtcNow(day1.AddDays(3));
+        var missedCard = await CreateCardAt(db, _time.GetUtcNow().AddMinutes(-5));
+        // skip reviewing missedCard on day 4
+
+        _time.SetUtcNow(day1.AddDays(4));
+        await reviewSvc.RateCard(UserId, new RateCardRequest(missedCard, "good"));
+
+        // Current streak should be 1 (only today), but BestStreak should still be 3
+        {
+            await using var db2 = _db.CreateDbContext();
+            var statsSvc = CreateStatsService(db2);
+            var stats = await statsSvc.GetStats(UserId);
+            stats.CurrentStreak.Should().Be(1);
+            stats.BestStreak.Should().Be(3);
+        }
+    }
+}

--- a/fasolt.Tests/SuspensionTests.cs
+++ b/fasolt.Tests/SuspensionTests.cs
@@ -16,7 +16,7 @@ public class SuspensionTests : IAsyncLifetime
     public async Task DisposeAsync() => await _db.DisposeAsync();
 
     private ReviewService CreateReviewService(Server.Infrastructure.Data.AppDbContext db)
-        => new(db, _time);
+        => new(db, _time, new StudyStatsService(db, _time));
 
     // --- GetDueCards excludes suspended cards ---
 

--- a/fasolt.client/src/stores/review.ts
+++ b/fasolt.client/src/stores/review.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import type { DueCard, ReviewStats } from '@/types'
+import type { DueCard, ReviewStats, StudyStats } from '@/types'
 import { apiFetch } from '@/api/client'
 
 export const useReviewStore = defineStore('review', () => {
@@ -119,9 +119,13 @@ export const useReviewStore = defineStore('review', () => {
     return apiFetch<ReviewStats>('/review/stats')
   }
 
+  async function fetchStudyStats(): Promise<StudyStats> {
+    return apiFetch<StudyStats>('/review/study-stats')
+  }
+
   return {
     queue, currentCard, isFlipped, isActive, isComplete, noDueCards, loading, error,
     progress, sessionStats, sessionTime,
-    startSession, flipCard, skip, suspend, rate, endSession, fetchStats,
+    startSession, flipCard, skip, suspend, rate, endSession, fetchStats, fetchStudyStats,
   }
 })

--- a/fasolt.client/src/types/index.ts
+++ b/fasolt.client/src/types/index.ts
@@ -69,6 +69,13 @@ export interface ReviewStats {
   studiedToday: number
 }
 
+export interface StudyStats {
+  currentStreak: number
+  bestStreak: number
+  totalAnswered: number
+  answeredToday: number
+}
+
 export interface SourceItem {
   sourceFile: string
   cardCount: number

--- a/fasolt.client/src/views/StudyView.vue
+++ b/fasolt.client/src/views/StudyView.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import { useReviewStore } from '@/stores/review'
 import { useDecksStore } from '@/stores/decks'
 import { apiFetch } from '@/api/client'
-import type { Deck } from '@/types'
+import type { Deck, StudyStats } from '@/types'
 import { Button } from '@/components/ui/button'
 
 const router = useRouter()
@@ -17,6 +17,7 @@ const dueCount = ref(0)
 const totalCards = ref(0)
 const studiedToday = ref(0)
 const creatingDemo = ref(false)
+const studyStats = ref<StudyStats>({ currentStreak: 0, bestStreak: 0, totalAnswered: 0, answeredToday: 0 })
 
 onMounted(async () => {
   try {
@@ -26,6 +27,11 @@ onMounted(async () => {
     studiedToday.value = stats.studiedToday
   } catch {
     // leave as 0
+  }
+  try {
+    studyStats.value = await reviewStore.fetchStudyStats()
+  } catch {
+    // leave as zeros — backend may not be deployed yet
   }
   decksStore.fetchDecks()
 })
@@ -61,6 +67,16 @@ async function createDemoDeck() {
     <div v-if="totalCards > 0" class="flex justify-center gap-7 text-sm text-muted-foreground">
       <div><span class="font-bold text-foreground">{{ totalCards }}</span> total</div>
       <div><span class="font-bold text-foreground">{{ studiedToday }}</span> today</div>
+    </div>
+
+    <!-- Study stats -->
+    <div v-if="studyStats.totalAnswered > 0" class="flex justify-center gap-7 text-sm text-muted-foreground">
+      <div v-if="studyStats.currentStreak > 0">
+        <span class="font-bold text-foreground">🔥 {{ studyStats.currentStreak }}</span> day streak
+      </div>
+      <div><span class="font-bold text-foreground">{{ studyStats.totalAnswered }}</span> answered</div>
+      <div><span class="font-bold text-foreground">{{ studyStats.answeredToday }}</span> today</div>
+      <div v-if="studyStats.bestStreak > 0"><span class="font-bold text-foreground">{{ studyStats.bestStreak }}</span> best</div>
     </div>
 
     <!-- Empty state -->

--- a/fasolt.ios/Fasolt/Models/APIModels.swift
+++ b/fasolt.ios/Fasolt/Models/APIModels.swift
@@ -114,6 +114,13 @@ struct ReviewStatsDTO: Decodable, Sendable {
     let studiedToday: Int
 }
 
+struct StudyStatsDTO: Decodable, Sendable {
+    let currentStreak: Int
+    let bestStreak: Int
+    let totalAnswered: Int
+    let answeredToday: Int
+}
+
 // MARK: - Overview
 
 struct OverviewDTO: Decodable, Sendable {

--- a/fasolt.ios/Fasolt/ViewModels/DashboardViewModel.swift
+++ b/fasolt.ios/Fasolt/ViewModels/DashboardViewModel.swift
@@ -12,6 +12,7 @@ final class DashboardViewModel {
     var cardsByState: [String: Int] = [:]
     var totalDecks: Int = 0
     var decks: [DeckDTO] = []
+    var studyStats: StudyStatsDTO?
     var isLoading = false
     var errorMessage: String?
     var isCreatingDemo = false
@@ -44,8 +45,12 @@ final class DashboardViewModel {
             do { return .success(try await deckRepository.fetchDecks()) }
             catch { return .failure(error) }
         }()
+        async let studyStatsResult: Result<StudyStatsDTO, Error> = {
+            do { return .success(try await apiClient.request(Endpoint(path: "/api/review/study-stats", method: .get))) }
+            catch { return .failure(error) }
+        }()
 
-        let (stats, overview, decksFetched) = await (statsResult, overviewResult, decksResult)
+        let (stats, overview, decksFetched, studyStatsFetched) = await (statsResult, overviewResult, decksResult, studyStatsResult)
 
         var failed = false
         if case .success(let s) = stats {
@@ -62,6 +67,13 @@ final class DashboardViewModel {
         if case .success(let d) = decksFetched {
             decks = d
         } else { failed = true }
+
+        if case .success(let ss) = studyStatsFetched {
+            studyStats = ss
+        } else {
+            logger.error("Failed to load study stats")
+            failed = true
+        }
 
         if failed {
             logger.error("Partial loadStats failure")

--- a/fasolt.ios/Fasolt/Views/Cards/CardListView.swift
+++ b/fasolt.ios/Fasolt/Views/Cards/CardListView.swift
@@ -51,6 +51,7 @@ struct CardListContent: View {
             await viewModel.loadCards()
         }
         .navigationTitle("Cards")
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {

--- a/fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift
+++ b/fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift
@@ -48,6 +48,7 @@ struct DashboardView: View {
                 await viewModel.loadStats()
             }
             .navigationTitle("Dashboard")
+            .navigationBarTitleDisplayMode(.inline)
             .overlay {
                 if viewModel.isLoading && viewModel.totalCards == 0 {
                     ProgressView()

--- a/fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift
+++ b/fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift
@@ -14,11 +14,10 @@ struct DashboardView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 16) {
-                    heroCard
                     if (viewModel.studyStats?.totalAnswered ?? 0) > 0 {
-                        streakBanner
+                        statsRow
                     }
-                    statsRow
+                    heroCard
                     if viewModel.totalCards > 0 {
                         stateBar
                     }
@@ -177,57 +176,35 @@ struct DashboardView: View {
     }
 
     private var statsRow: some View {
-        HStack(spacing: 8) {
-            if let ss = viewModel.studyStats {
-                statPill("Answered", value: "\(ss.totalAnswered)")
-                statPill("Today", value: "\(ss.answeredToday)")
-                statPill("Best", value: "\(ss.bestStreak)")
-            } else {
-                statPill("Total", value: "\(viewModel.totalCards)")
-                statPill("Today", value: "\(viewModel.studiedToday)")
-                statPill("Decks", value: "\(viewModel.totalDecks)")
-            }
-        }
-    }
-
-    private var streakBanner: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "flame.fill")
-                .foregroundStyle(.orange)
-                .font(.title2)
-            VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 14) {
+            HStack(spacing: 5) {
+                Image(systemName: "flame.fill")
+                    .foregroundStyle(.orange)
+                    .font(.subheadline)
                 Text("\(viewModel.studyStats?.currentStreak ?? 0)")
-                    .font(.title.weight(.bold).monospacedDigit())
+                    .font(.subheadline.weight(.bold).monospacedDigit())
                 Text("day streak")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            Spacer()
-            VStack(alignment: .trailing, spacing: 2) {
-                Text("best")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                Text("\(viewModel.studyStats?.bestStreak ?? 0)")
-                    .font(.subheadline.weight(.semibold).monospacedDigit())
-                    .foregroundStyle(.secondary)
-            }
+            Spacer(minLength: 8)
+            inlineStat(value: viewModel.studyStats?.answeredToday ?? 0, label: "today")
+            inlineStat(value: viewModel.studyStats?.totalAnswered ?? 0, label: "total")
+            inlineStat(value: viewModel.studyStats?.bestStreak ?? 0, label: "best")
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
     }
 
-    private func statPill(_ label: String, value: String) -> some View {
-        VStack(spacing: 4) {
+    private func inlineStat(value: Int, label: String) -> some View {
+        HStack(spacing: 3) {
+            Text("\(value)")
+                .font(.subheadline.weight(.semibold).monospacedDigit())
             Text(label)
-                .font(.caption2)
+                .font(.caption)
                 .foregroundStyle(.secondary)
-            Text(value)
-                .font(.title3.weight(.semibold))
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
     }
 
     private var deckSection: some View {

--- a/fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift
+++ b/fasolt.ios/Fasolt/Views/Dashboard/DashboardView.swift
@@ -15,6 +15,9 @@ struct DashboardView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     heroCard
+                    if (viewModel.studyStats?.totalAnswered ?? 0) > 0 {
+                        streakBanner
+                    }
                     statsRow
                     if viewModel.totalCards > 0 {
                         stateBar
@@ -175,10 +178,43 @@ struct DashboardView: View {
 
     private var statsRow: some View {
         HStack(spacing: 8) {
-            statPill("Total", value: "\(viewModel.totalCards)")
-            statPill("Today", value: "\(viewModel.studiedToday)")
-            statPill("Decks", value: "\(viewModel.totalDecks)")
+            if let ss = viewModel.studyStats {
+                statPill("Answered", value: "\(ss.totalAnswered)")
+                statPill("Today", value: "\(ss.answeredToday)")
+                statPill("Best", value: "\(ss.bestStreak)")
+            } else {
+                statPill("Total", value: "\(viewModel.totalCards)")
+                statPill("Today", value: "\(viewModel.studiedToday)")
+                statPill("Decks", value: "\(viewModel.totalDecks)")
+            }
         }
+    }
+
+    private var streakBanner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "flame.fill")
+                .foregroundStyle(.orange)
+                .font(.title2)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(viewModel.studyStats?.currentStreak ?? 0)")
+                    .font(.title.weight(.bold).monospacedDigit())
+                Text("day streak")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("best")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text("\(viewModel.studyStats?.bestStreak ?? 0)")
+                    .font(.subheadline.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
     }
 
     private func statPill(_ label: String, value: String) -> some View {

--- a/fasolt.ios/Fasolt/Views/Decks/DeckDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Decks/DeckDetailView.swift
@@ -137,6 +137,7 @@ struct DeckDetailView: View {
             }
         }
         .navigationTitle(viewModel.deckName)
+        .navigationBarTitleDisplayMode(.inline)
         .offlineBanner()
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/fasolt.ios/Fasolt/Views/Decks/DeckListView.swift
+++ b/fasolt.ios/Fasolt/Views/Decks/DeckListView.swift
@@ -44,6 +44,7 @@ struct DeckListContent: View {
             .searchable(text: $searchText, prompt: "Search decks")
             .refreshable { await viewModel.loadDecks() }
             .navigationTitle("Decks")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar { toolbarContent }
             .overlay { if viewModel.isLoading && viewModel.decks.isEmpty { ProgressView() } }
             .offlineBanner()

--- a/fasolt.ios/Fasolt/Views/Settings/SettingsView.swift
+++ b/fasolt.ios/Fasolt/Views/Settings/SettingsView.swift
@@ -44,6 +44,7 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     NavigationLink {


### PR DESCRIPTION
Closes #150.

## Summary

- Adds **current streak**, **best streak**, **total answered**, and **answered today** to the web and iOS dashboards.
- New `ReviewLog` entity captures every rate event (rating, scheduled-due, state) — append-only.
- `BestStreak` persisted on `AppUser`, recomputed on each review.
- New `StudyStatsService` implements rest-day-aware streak logic: a day with no due cards never breaks the streak; only a day with due cards and zero reviews does.
- New endpoint `GET /api/review/study-stats`.

## Streak semantics

- Today is in-progress: not reviewing today doesn't break the streak; reviewing extends it.
- Walk back day-by-day from today (max 365). Study day → +1; due-day-with-no-review → break; no-due day → preserved.
- "Due day" reconstructed from review-log history: most-recent `ScheduledDueAfter` ≤ end-of-day, falling back to `Card.CreatedAt` for cards with no log rows.

Note: history before this PR is not backfilled. Existing users start streak/total at zero and grow from here.

## What changed

- Backend: `ReviewLog` entity + migration `AddReviewLogAndBestStreak`, `StudyStatsService`, `StudyStatsDto`, endpoint, `ReviewService` logs each rating, `Program.cs` DI.
- Web: `StudyStats` type, `fetchStudyStats` store action, four-stat row in `StudyView.vue` (hidden when no review history).
- iOS: `StudyStatsDTO`, `DashboardViewModel` parallel fetch, streak banner + repurposed stats pills in `DashboardView.swift`.
- Tests: 6 new `StudyStatsServiceTests` (empty, single review, consecutive days, rest-day gap, due-day gap break, best-streak persistence).

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test fasolt.Tests` — 288/288 pass
- [x] `npx tsc --noEmit && npm run build` — clean
- [x] Manual: logged in as `dev@fasolt.local`, rated a card with `Good`, refreshed dashboard — saw `🔥 1 day streak • 1 answered • 1 today • 1 best`.
- [ ] iOS build verified — xcodebuild couldn't run on this machine (CoreSimulator version mismatch); changes reviewed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)