### PR TITLE
General improvements: admin Last Active, MCP identity, full-width admin, test cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ The server exposes a remote MCP endpoint at `/mcp` (streamable HTTP transport). 
 - `DeleteDeck` — delete a deck, optionally deleting all its cards too
 - `AssignCardsToDeck` — assign cards to a deck, remove from a deck, or move between decks
 - `SetDeckActive` — activate or deactivate a deck for study
-- `GetOverview` — get account overview: total cards, due cards, cards by state, deck and source counts
+- `GetOverview` — get account overview: identity, total cards, due cards, cards by state, deck and source counts
 
 ## Agent Teams
 

--- a/fasolt.Server/Api/McpTools/OverviewTools.cs
+++ b/fasolt.Server/Api/McpTools/OverviewTools.cs
@@ -8,11 +8,23 @@ namespace Fasolt.Server.Api.McpTools;
 [McpServerToolType]
 public class OverviewTools(OverviewService overviewService, IHttpContextAccessor httpContextAccessor)
 {
-    [McpServerTool, Description("Get an overview of the user's account: total cards, due cards, cards by state, deck count, and source file count.")]
+    [McpServerTool, Description("Get an overview of the user's account: identity, total cards, due cards, cards by state, deck count, and source file count. Call this first to confirm which Fasolt account is connected.")]
     public async Task<string> GetOverview()
     {
         var userId = McpUserResolver.GetUserId(httpContextAccessor);
-        var result = await overviewService.GetOverview(userId);
-        return JsonSerializer.Serialize(result, McpJson.Options);
+        var identity = await overviewService.GetIdentity(userId);
+        var overview = await overviewService.GetOverview(userId);
+
+        var response = new
+        {
+            identity,
+            overview.TotalCards,
+            overview.DueCards,
+            overview.CardsByState,
+            overview.TotalDecks,
+            overview.TotalSources,
+        };
+
+        return JsonSerializer.Serialize(response, McpJson.Options);
     }
 }

--- a/fasolt.Server/Application/Dtos/AdminDtos.cs
+++ b/fasolt.Server/Application/Dtos/AdminDtos.cs
@@ -9,7 +9,8 @@ public record AdminUserDto(
     int DeckCount,
     bool IsLockedOut,
     bool HasPush,
-    bool EmailConfirmed);
+    bool EmailConfirmed,
+    DateTimeOffset? LastActivityAt);
 
 public record AdminUserListResponse(
     List<AdminUserDto> Users,

--- a/fasolt.Server/Application/Dtos/OverviewDtos.cs
+++ b/fasolt.Server/Application/Dtos/OverviewDtos.cs
@@ -6,3 +6,8 @@ public record OverviewDto(
     Dictionary<string, int> CardsByState,
     int TotalDecks,
     int TotalSources);
+
+public record OverviewIdentityDto(
+    string Email,
+    string? DisplayName,
+    string? ExternalProvider);

--- a/fasolt.Server/Application/Services/AdminService.cs
+++ b/fasolt.Server/Application/Services/AdminService.cs
@@ -44,21 +44,48 @@ public class AdminService(AppDbContext db, ApnsService? apnsService = null)
 
         var totalCount = await query.CountAsync();
 
-        var users = await query
+        var rows = await query
             .OrderBy(u => u.Email)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
-            .Select(u => new AdminUserDto(
+            .Select(u => new
+            {
+                u.Id,
+                u.Email,
+                u.UserName,
+                u.ExternalProvider,
+                u.LockoutEnabled,
+                u.LockoutEnd,
+                u.EmailConfirmed,
+                CardCount = db.Cards.Count(c => c.UserId == u.Id),
+                DeckCount = db.Decks.Count(d => d.UserId == u.Id),
+                HasPush = db.DeviceTokens.Any(d => d.UserId == u.Id),
+                LastReviewAt = db.ReviewLogs.Where(r => r.UserId == u.Id).Max(r => (DateTimeOffset?)r.ReviewedAt),
+                LastCardCreatedAt = db.Cards.Where(c => c.UserId == u.Id).Max(c => (DateTimeOffset?)c.CreatedAt),
+                LastDeckCreatedAt = db.Decks.Where(d => d.UserId == u.Id).Max(d => (DateTimeOffset?)d.CreatedAt),
+                u.LastLoginAt,
+            })
+            .ToListAsync();
+
+        var users = rows.Select(u =>
+        {
+            var times = new[] { u.LastReviewAt, u.LastCardCreatedAt, u.LastDeckCreatedAt, u.LastLoginAt }
+                .Where(t => t.HasValue)
+                .Select(t => t!.Value)
+                .ToList();
+            DateTimeOffset? lastActivity = times.Count > 0 ? times.Max() : null;
+            return new AdminUserDto(
                 u.Id,
                 u.Email!,
                 u.ExternalProvider != null ? u.UserName : null,
                 u.ExternalProvider,
-                db.Cards.Count(c => c.UserId == u.Id),
-                db.Decks.Count(d => d.UserId == u.Id),
+                u.CardCount,
+                u.DeckCount,
                 u.LockoutEnabled && u.LockoutEnd > now,
-                db.DeviceTokens.Any(d => d.UserId == u.Id),
-                u.EmailConfirmed))
-            .ToListAsync();
+                u.HasPush,
+                u.EmailConfirmed,
+                lastActivity);
+        }).ToList();
 
         return new AdminUserListResponse(users, totalCount, page, pageSize);
     }

--- a/fasolt.Server/Application/Services/OverviewService.cs
+++ b/fasolt.Server/Application/Services/OverviewService.cs
@@ -42,4 +42,15 @@ public class OverviewService(AppDbContext db)
 
         return new OverviewDto(totalCards, dueCards, cardsByState, totalDecks, totalSources);
     }
+
+    public async Task<OverviewIdentityDto?> GetIdentity(string userId)
+    {
+        return await db.Users
+            .Where(u => u.Id == userId)
+            .Select(u => new OverviewIdentityDto(
+                u.Email!,
+                u.ExternalProvider != null ? u.UserName : null,
+                u.ExternalProvider))
+            .FirstOrDefaultAsync();
+    }
 }

--- a/fasolt.Server/Domain/Entities/AppUser.cs
+++ b/fasolt.Server/Domain/Entities/AppUser.cs
@@ -13,4 +13,5 @@ public class AppUser : IdentityUser
     public string? ExternalProvider { get; set; }
     public string? ExternalProviderId { get; set; }
     public int BestStreak { get; set; } = 0;
+    public DateTimeOffset? LastLoginAt { get; set; }
 }

--- a/fasolt.Server/Infrastructure/Data/Migrations/20260517191917_AddAppUserLastLoginAt.Designer.cs
+++ b/fasolt.Server/Infrastructure/Data/Migrations/20260517191917_AddAppUserLastLoginAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fasolt.Server.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Fasolt.Server.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517191917_AddAppUserLastLoginAt")]
+    partial class AddAppUserLastLoginAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/fasolt.Server/Infrastructure/Data/Migrations/20260517191917_AddAppUserLastLoginAt.cs
+++ b/fasolt.Server/Infrastructure/Data/Migrations/20260517191917_AddAppUserLastLoginAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fasolt.Server.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAppUserLastLoginAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LastLoginAt",
+                table: "AspNetUsers",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastLoginAt",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/fasolt.Server/Infrastructure/Services/TrackingSignInManager.cs
+++ b/fasolt.Server/Infrastructure/Services/TrackingSignInManager.cs
@@ -1,0 +1,28 @@
+using System.Security.Claims;
+using Fasolt.Server.Domain.Entities;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace Fasolt.Server.Infrastructure.Services;
+
+public class TrackingSignInManager(
+    UserManager<AppUser> userManager,
+    IHttpContextAccessor contextAccessor,
+    IUserClaimsPrincipalFactory<AppUser> claimsFactory,
+    IOptions<IdentityOptions> optionsAccessor,
+    ILogger<SignInManager<AppUser>> logger,
+    IAuthenticationSchemeProvider schemes,
+    IUserConfirmation<AppUser> confirmation)
+    : SignInManager<AppUser>(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
+{
+    public override async Task SignInWithClaimsAsync(
+        AppUser user,
+        AuthenticationProperties? authenticationProperties,
+        IEnumerable<Claim> additionalClaims)
+    {
+        user.LastLoginAt = DateTimeOffset.UtcNow;
+        await UserManager.UpdateAsync(user);
+        await base.SignInWithClaimsAsync(user, authenticationProperties, additionalClaims);
+    }
+}

--- a/fasolt.Server/Program.cs
+++ b/fasolt.Server/Program.cs
@@ -69,7 +69,8 @@ builder.Services
     })
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<AppDbContext>()
-    .AddClaimsPrincipalFactory<AppClaimsPrincipalFactory>();
+    .AddClaimsPrincipalFactory<AppClaimsPrincipalFactory>()
+    .AddSignInManager<TrackingSignInManager>();
 
 var gitHubClientId = builder.Configuration["GITHUB_CLIENT_ID"];
 var gitHubClientSecret = builder.Configuration["GITHUB_CLIENT_SECRET"];

--- a/fasolt.Tests/Auth/AppleTokenEndpointTests.cs
+++ b/fasolt.Tests/Auth/AppleTokenEndpointTests.cs
@@ -13,13 +13,16 @@ using Fasolt.Tests.Helpers;
 namespace Fasolt.Tests.Auth;
 
 [Collection(WebAppCollection.Name)]
-public class AppleTokenEndpointTests
+public class AppleTokenEndpointTests : IAsyncLifetime
 {
     private const string BundleId = "com.fasolt.app";
     private const string Kid = "test-kid";
 
     private readonly WebApplicationFactory<Program> _factory;
     private readonly RSA _signingKey;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => TestUserCleanup.DeleteTestUsersAsync(_factory);
 
     public AppleTokenEndpointTests(WebApplicationFactory<Program> factory)
     {

--- a/fasolt.Tests/Auth/AppleWebCallbackTests.cs
+++ b/fasolt.Tests/Auth/AppleWebCallbackTests.cs
@@ -12,13 +12,16 @@ using Fasolt.Tests.Helpers;
 namespace Fasolt.Tests.Auth;
 
 [Collection(WebAppCollection.Name)]
-public class AppleWebCallbackTests
+public class AppleWebCallbackTests : IAsyncLifetime
 {
     private const string WebClientId = "app.fasolt.web";
     private const string Kid = "test-kid";
 
     private readonly WebApplicationFactory<Program> _factory;
     private readonly RSA _signingKey;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => TestUserCleanup.DeleteTestUsersAsync(_factory);
 
     public AppleWebCallbackTests(WebApplicationFactory<Program> factory)
     {

--- a/fasolt.Tests/Auth/AppleWebCallbackTests.cs
+++ b/fasolt.Tests/Auth/AppleWebCallbackTests.cs
@@ -147,7 +147,7 @@ public class AppleWebCallbackTests : IAsyncLifetime
     public async Task AppleCallback_WithValidToken_CreatesNewUser()
     {
         var uniqueSub = $"apple-web-new-{Guid.NewGuid():N}";
-        var uniqueEmail = $"new-{Guid.NewGuid():N}@icloud.com";
+        var uniqueEmail = TestEmail.Create("icloud.com");
         var idToken = MakeAppleIdToken(uniqueSub, uniqueEmail, true);
         var state = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("/"));
 
@@ -175,7 +175,7 @@ public class AppleWebCallbackTests : IAsyncLifetime
     [Fact]
     public async Task AppleCallback_PreservesReturnUrl_FromState()
     {
-        var idToken = MakeAppleIdToken($"apple-web-ret-{Guid.NewGuid():N}", $"ret-{Guid.NewGuid():N}@icloud.com", true);
+        var idToken = MakeAppleIdToken($"apple-web-ret-{Guid.NewGuid():N}", TestEmail.Create("icloud.com"), true);
         var state = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("/decks"));
 
         var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
@@ -195,7 +195,7 @@ public class AppleWebCallbackTests : IAsyncLifetime
     [Fact]
     public async Task AppleCallback_RejectsNonLocalReturnUrl()
     {
-        var idToken = MakeAppleIdToken($"apple-web-xss-{Guid.NewGuid():N}", $"xss-{Guid.NewGuid():N}@icloud.com", true);
+        var idToken = MakeAppleIdToken($"apple-web-xss-{Guid.NewGuid():N}", TestEmail.Create("icloud.com"), true);
         var state = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("https://evil.com"));
 
         var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });

--- a/fasolt.Tests/Auth/OAuthConsentPageTests.cs
+++ b/fasolt.Tests/Auth/OAuthConsentPageTests.cs
@@ -11,9 +11,12 @@ using Fasolt.Tests.Helpers;
 namespace Fasolt.Tests.Auth;
 
 [Collection(WebAppCollection.Name)]
-public class OAuthConsentPageTests
+public class OAuthConsentPageTests : IAsyncLifetime
 {
     private readonly WebApplicationFactory<Program> _factory;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => TestUserCleanup.DeleteTestUsersAsync(_factory);
 
     public OAuthConsentPageTests(WebApplicationFactory<Program> factory)
     {

--- a/fasolt.Tests/Auth/OAuthConsentPageTests.cs
+++ b/fasolt.Tests/Auth/OAuthConsentPageTests.cs
@@ -36,7 +36,7 @@ public class OAuthConsentPageTests : IAsyncLifetime
     [Fact]
     public async Task Get_WithSnakeCaseClientId_RendersConsentPage()
     {
-        var email = $"consent-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         const string password = "Abcdefg1";
         var clientId = $"test-client-{Guid.NewGuid():N}";
 

--- a/fasolt.Tests/Auth/OAuthForgotPasswordEndpointTests.cs
+++ b/fasolt.Tests/Auth/OAuthForgotPasswordEndpointTests.cs
@@ -11,9 +11,12 @@ using Fasolt.Tests.Helpers;
 namespace Fasolt.Tests.Auth;
 
 [Collection(WebAppCollection.Name)]
-public class OAuthForgotPasswordEndpointTests
+public class OAuthForgotPasswordEndpointTests : IAsyncLifetime
 {
     private readonly WebApplicationFactory<Program> _factory;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => TestUserCleanup.DeleteTestUsersAsync(_factory);
 
     public OAuthForgotPasswordEndpointTests(WebApplicationFactory<Program> factory)
     {

--- a/fasolt.Tests/Auth/OAuthForgotPasswordEndpointTests.cs
+++ b/fasolt.Tests/Auth/OAuthForgotPasswordEndpointTests.cs
@@ -64,7 +64,7 @@ public class OAuthForgotPasswordEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Post_ForExistingConfirmedUser_CreatesResetCode_AndRedirectsToSent()
     {
-        var email = $"reset-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         string userId;
         using (var scope = _factory.Services.CreateScope())
         {
@@ -113,7 +113,7 @@ public class OAuthForgotPasswordEndpointTests : IAsyncLifetime
         var csrfToken = ExtractCsrfToken(await getResponse.Content.ReadAsStringAsync());
         var cookieHeader = getResponse.Headers.GetValues("Set-Cookie").FirstOrDefault() ?? "";
 
-        var email = $"does-not-exist-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["__RequestVerificationToken"] = csrfToken,
@@ -140,7 +140,7 @@ public class OAuthForgotPasswordEndpointTests : IAsyncLifetime
     {
         // GitHub/Apple users have no password to reset. Must not create a
         // dangling OTP row and must not reveal that the account is external.
-        var email = $"gh-{Guid.NewGuid():N}@users.noreply.github.com";
+        var email = TestEmail.Create("users.noreply.github.com");
         string userId;
         using (var scope = _factory.Services.CreateScope())
         {

--- a/fasolt.Tests/Auth/OAuthLoginPageTests.cs
+++ b/fasolt.Tests/Auth/OAuthLoginPageTests.cs
@@ -7,9 +7,12 @@ using Fasolt.Tests.Helpers;
 namespace Fasolt.Tests.Auth;
 
 [Collection(WebAppCollection.Name)]
-public class OAuthLoginPageTests
+public class OAuthLoginPageTests : IAsyncLifetime
 {
     private readonly WebApplicationFactory<Program> _factory;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => TestUserCleanup.DeleteTestUsersAsync(_factory);
 
     public OAuthLoginPageTests(WebApplicationFactory<Program> factory)
     {

--- a/fasolt.Tests/Auth/OAuthLoginPageTests.cs
+++ b/fasolt.Tests/Auth/OAuthLoginPageTests.cs
@@ -99,7 +99,7 @@ public class OAuthLoginPageTests : IAsyncLifetime
     [Fact]
     public async Task Post_InvalidPassword_RendersFormWithError()
     {
-        var email = $"wrong-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         using (var scope = _factory.Services.CreateScope())
         {
             var userManager = scope.ServiceProvider.GetRequiredService<Microsoft.AspNetCore.Identity.UserManager<AppUser>>();
@@ -133,7 +133,7 @@ public class OAuthLoginPageTests : IAsyncLifetime
     [Fact]
     public async Task Post_ValidCredentials_RedirectsToReturnUrlAndSetsCookie()
     {
-        var email = $"ok-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         const string password = "Abcdefg1";
         using (var scope = _factory.Services.CreateScope())
         {
@@ -172,7 +172,7 @@ public class OAuthLoginPageTests : IAsyncLifetime
     [Fact]
     public async Task Post_MaliciousReturnUrl_RedirectsToRootNotEvilDomain()
     {
-        var email = $"redirect-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         const string password = "Abcdefg1";
         using (var scope = _factory.Services.CreateScope())
         {
@@ -207,7 +207,7 @@ public class OAuthLoginPageTests : IAsyncLifetime
     [Fact]
     public async Task Post_UnverifiedUser_RedirectsToVerifyEmail()
     {
-        var email = $"unverified-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         const string password = "Abcdefg1";
         using (var scope = _factory.Services.CreateScope())
         {
@@ -272,7 +272,7 @@ public class OAuthLoginPageTests : IAsyncLifetime
     [Fact]
     public async Task Post_RepeatedWrongPassword_TriggersLockout()
     {
-        var email = $"lockout-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         const string password = "Abcdefg1";
         using (var scope = _factory.Services.CreateScope())
         {
@@ -329,7 +329,7 @@ public class OAuthLoginPageTests : IAsyncLifetime
     [Fact]
     public async Task Get_AuthenticatedUser_RedirectsToReturnUrl()
     {
-        var email = $"authed-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         const string password = "Abcdefg1";
         using (var scope = _factory.Services.CreateScope())
         {

--- a/fasolt.Tests/Auth/OAuthRegisterEndpointTests.cs
+++ b/fasolt.Tests/Auth/OAuthRegisterEndpointTests.cs
@@ -10,9 +10,12 @@ using Fasolt.Tests.Helpers;
 namespace Fasolt.Tests.Auth;
 
 [Collection(WebAppCollection.Name)]
-public class OAuthRegisterEndpointTests
+public class OAuthRegisterEndpointTests : IAsyncLifetime
 {
     private readonly WebApplicationFactory<Program> _factory;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => TestUserCleanup.DeleteTestUsersAsync(_factory);
 
     public OAuthRegisterEndpointTests(WebApplicationFactory<Program> factory)
     {

--- a/fasolt.Tests/Auth/OAuthRegisterEndpointTests.cs
+++ b/fasolt.Tests/Auth/OAuthRegisterEndpointTests.cs
@@ -61,7 +61,7 @@ public class OAuthRegisterEndpointTests : IAsyncLifetime
         var csrfToken = ExtractCsrfToken(await getResponse.Content.ReadAsStringAsync());
         var cookieHeader = getResponse.Headers.GetValues("Set-Cookie").FirstOrDefault() ?? "";
 
-        var email = $"register-test-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["__RequestVerificationToken"] = csrfToken,
@@ -130,7 +130,7 @@ public class OAuthRegisterEndpointTests : IAsyncLifetime
         // Enumeration resistance: an attacker probing for a registered email
         // must see the same response as a fresh signup. We land on the
         // verify-email page with no new OTP row for the victim.
-        var email = $"confirmed-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         string userId;
         using (var scope = _factory.Services.CreateScope())
         {
@@ -178,7 +178,7 @@ public class OAuthRegisterEndpointTests : IAsyncLifetime
         // Griefing resistance: an anonymous POST must not trigger a new OTP
         // send against an existing unconfirmed account. The real user can
         // request a fresh code from the verify-email page instead.
-        var email = $"unconfirmed-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         string userId;
         using (var scope = _factory.Services.CreateScope())
         {
@@ -240,7 +240,7 @@ public class OAuthRegisterEndpointTests : IAsyncLifetime
         var csrfToken = ExtractCsrfToken(await getResponse.Content.ReadAsStringAsync());
         var cookieHeader = getResponse.Headers.GetValues("Set-Cookie").FirstOrDefault() ?? "";
 
-        var email = $"weak-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["__RequestVerificationToken"] = csrfToken,

--- a/fasolt.Tests/Auth/OAuthResetPasswordEndpointTests.cs
+++ b/fasolt.Tests/Auth/OAuthResetPasswordEndpointTests.cs
@@ -51,7 +51,7 @@ public class OAuthResetPasswordEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Post_WithCorrectCode_RotatesPassword_AndConsumesOtp()
     {
-        var email = $"reset-ok-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         const string oldPassword = "OldPass1A";
         const string newPassword = "NewPass1B";
         string userId;
@@ -109,7 +109,7 @@ public class OAuthResetPasswordEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Post_WithWrongCode_ShowsError_AndDoesNotRotatePassword()
     {
-        var email = $"reset-wrong-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         const string oldPassword = "OldPass1A";
         string userId;
 
@@ -157,7 +157,7 @@ public class OAuthResetPasswordEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Post_WithMismatchedPasswords_ShowsError()
     {
-        var email = $"reset-mismatch-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         using (var scope = _factory.Services.CreateScope())
         {
             var userManager = scope.ServiceProvider.GetRequiredService<Microsoft.AspNetCore.Identity.UserManager<AppUser>>();
@@ -197,7 +197,7 @@ public class OAuthResetPasswordEndpointTests : IAsyncLifetime
         // external-provider users from ever getting a code, but if one
         // somehow arrives (prior account conversion, test fixture, etc.)
         // reset-password must still refuse to rotate the password.
-        var email = $"gh-reset-{Guid.NewGuid():N}@users.noreply.github.com";
+        var email = TestEmail.Create("users.noreply.github.com");
         string userId;
         using (var scope = _factory.Services.CreateScope())
         {
@@ -251,7 +251,7 @@ public class OAuthResetPasswordEndpointTests : IAsyncLifetime
         // for (a) an unknown email and (b) a known confirmed user in active
         // cooldown. Otherwise an attacker can tell which emails are registered
         // by clicking "Resend" with each one.
-        var knownEmail = $"resend-{Guid.NewGuid():N}@example.com";
+        var knownEmail = TestEmail.Create();
         using (var scope = _factory.Services.CreateScope())
         {
             var userManager = scope.ServiceProvider.GetRequiredService<Microsoft.AspNetCore.Identity.UserManager<AppUser>>();
@@ -263,7 +263,7 @@ public class OAuthResetPasswordEndpointTests : IAsyncLifetime
             await otp.GenerateAndStoreAsync(user.Id, CancellationToken.None);
         }
 
-        var unknownEmail = $"nobody-{Guid.NewGuid():N}@example.com";
+        var unknownEmail = TestEmail.Create();
 
         async Task<string> PostResendAndReturnLocation(string email)
         {

--- a/fasolt.Tests/Auth/OAuthResetPasswordEndpointTests.cs
+++ b/fasolt.Tests/Auth/OAuthResetPasswordEndpointTests.cs
@@ -11,9 +11,12 @@ using Fasolt.Tests.Helpers;
 namespace Fasolt.Tests.Auth;
 
 [Collection(WebAppCollection.Name)]
-public class OAuthResetPasswordEndpointTests
+public class OAuthResetPasswordEndpointTests : IAsyncLifetime
 {
     private readonly WebApplicationFactory<Program> _factory;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => TestUserCleanup.DeleteTestUsersAsync(_factory);
 
     public OAuthResetPasswordEndpointTests(WebApplicationFactory<Program> factory)
     {

--- a/fasolt.Tests/Auth/OAuthVerifyEmailEndpointTests.cs
+++ b/fasolt.Tests/Auth/OAuthVerifyEmailEndpointTests.cs
@@ -50,7 +50,7 @@ public class OAuthVerifyEmailEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Post_WithCorrectCode_ConfirmsEmail_AndRedirectsToReturnUrl()
     {
-        var email = $"verify-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         string code;
         string userId;
 
@@ -114,7 +114,7 @@ public class OAuthVerifyEmailEndpointTests : IAsyncLifetime
     [Fact]
     public async Task Post_WithWrongCode_ShowsErrorInline()
     {
-        var email = $"wrong-{Guid.NewGuid():N}@example.com";
+        var email = TestEmail.Create();
         using (var scope = _factory.Services.CreateScope())
         {
             var userManager = scope.ServiceProvider.GetRequiredService<Microsoft.AspNetCore.Identity.UserManager<AppUser>>();

--- a/fasolt.Tests/Auth/OAuthVerifyEmailEndpointTests.cs
+++ b/fasolt.Tests/Auth/OAuthVerifyEmailEndpointTests.cs
@@ -11,9 +11,12 @@ using Fasolt.Tests.Helpers;
 namespace Fasolt.Tests.Auth;
 
 [Collection(WebAppCollection.Name)]
-public class OAuthVerifyEmailEndpointTests
+public class OAuthVerifyEmailEndpointTests : IAsyncLifetime
 {
     private readonly WebApplicationFactory<Program> _factory;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => TestUserCleanup.DeleteTestUsersAsync(_factory);
 
     public OAuthVerifyEmailEndpointTests(WebApplicationFactory<Program> factory)
     {

--- a/fasolt.Tests/Helpers/TestEmail.cs
+++ b/fasolt.Tests/Helpers/TestEmail.cs
@@ -1,0 +1,7 @@
+namespace Fasolt.Tests.Helpers;
+
+public static class TestEmail
+{
+    public static string Create(string domain = "example.com") =>
+        $"test-{Guid.NewGuid():N}@{domain}";
+}

--- a/fasolt.Tests/Helpers/TestUserCleanup.cs
+++ b/fasolt.Tests/Helpers/TestUserCleanup.cs
@@ -10,7 +10,7 @@ public static class TestUserCleanup
     {
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        const string pattern = "[a-f0-9]{32}";
+        const string pattern = "^test-[a-f0-9]{32}@";
         await db.Database.ExecuteSqlInterpolatedAsync(
             $"DELETE FROM \"AspNetUsers\" WHERE \"Email\" ~ {pattern}");
     }

--- a/fasolt.Tests/Helpers/TestUserCleanup.cs
+++ b/fasolt.Tests/Helpers/TestUserCleanup.cs
@@ -1,0 +1,17 @@
+using Fasolt.Server.Infrastructure.Data;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Fasolt.Tests.Helpers;
+
+public static class TestUserCleanup
+{
+    public static async Task DeleteTestUsersAsync(WebApplicationFactory<Program> factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        const string pattern = "[a-f0-9]{32}";
+        await db.Database.ExecuteSqlInterpolatedAsync(
+            $"DELETE FROM \"AspNetUsers\" WHERE \"Email\" ~ {pattern}");
+    }
+}

--- a/fasolt.client/src/layouts/AppLayout.vue
+++ b/fasolt.client/src/layouts/AppLayout.vue
@@ -61,7 +61,7 @@ const activeTab = computed(() => {
       </Tabs>
     </nav>
     <main class="flex-1 px-4 pb-20 pt-6 sm:px-5 sm:pb-6">
-      <div class="mx-auto max-w-[1200px]">
+      <div :class="route.meta.fullWidth ? '' : 'mx-auto max-w-[1200px]'">
         <slot />
       </div>
     </main>

--- a/fasolt.client/src/router/index.ts
+++ b/fasolt.client/src/router/index.ts
@@ -64,7 +64,7 @@ const router = createRouter({
     {
       path: '/admin',
       component: () => import('@/layouts/AdminLayout.vue'),
-      meta: { requiresAdmin: true, title: 'Admin' },
+      meta: { requiresAdmin: true, title: 'Admin', fullWidth: true },
       redirect: '/admin/overview',
       children: [
         { path: 'overview', name: 'admin-overview', component: () => import('@/views/admin/AdminOverviewView.vue'), meta: { requiresAdmin: true, title: 'Admin · Overview' } },

--- a/fasolt.client/src/views/admin/AdminUsersView.vue
+++ b/fasolt.client/src/views/admin/AdminUsersView.vue
@@ -26,6 +26,7 @@ interface AdminUser {
   isLockedOut: boolean
   hasPush: boolean
   emailConfirmed: boolean
+  lastActivityAt: string | null
 }
 
 interface AdminUserListResponse {
@@ -167,6 +168,18 @@ function clearFilters() {
 const hasActiveFilters = () =>
   !!(search.value || providerFilter.value || lockedOnly.value || hasPushOnly.value)
 
+function formatLastActivity(iso: string | null): string {
+  if (!iso) return '—'
+  const then = new Date(iso).getTime()
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000))
+  if (diffSec < 60) return 'just now'
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
+  if (diffSec < 86400 * 30) return `${Math.floor(diffSec / 86400)}d ago`
+  if (diffSec < 86400 * 365) return `${Math.floor(diffSec / (86400 * 30))}mo ago`
+  return `${Math.floor(diffSec / (86400 * 365))}y ago`
+}
+
 onMounted(fetchUsers)
 </script>
 
@@ -228,15 +241,16 @@ onMounted(fetchUsers)
             <TableHead class="text-right">Decks</TableHead>
             <TableHead>Push</TableHead>
             <TableHead>Status</TableHead>
+            <TableHead>Last active</TableHead>
             <TableHead class="text-right">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           <TableRow v-if="isLoading">
-            <TableCell :colspan="7" class="text-center text-muted-foreground">Loading…</TableCell>
+            <TableCell :colspan="8" class="text-center text-muted-foreground">Loading…</TableCell>
           </TableRow>
           <TableRow v-else-if="users.length === 0">
-            <TableCell :colspan="7" class="text-center text-muted-foreground">No users match the current filters.</TableCell>
+            <TableCell :colspan="8" class="text-center text-muted-foreground">No users match the current filters.</TableCell>
           </TableRow>
           <TableRow v-for="u in users" :key="u.id">
             <TableCell class="font-medium">
@@ -269,6 +283,12 @@ onMounted(fetchUsers)
             <TableCell>
               <Badge v-if="u.isLockedOut" variant="destructive">Locked</Badge>
               <Badge v-else variant="secondary">Active</Badge>
+            </TableCell>
+            <TableCell
+              class="whitespace-nowrap text-sm text-muted-foreground"
+              :title="u.lastActivityAt ? new Date(u.lastActivityAt).toLocaleString() : ''"
+            >
+              {{ formatLastActivity(u.lastActivityAt) }}
             </TableCell>
             <TableCell class="text-right flex gap-1 justify-end">
               <Button v-if="u.hasPush" variant="outline" size="sm" :disabled="pushingUserId === u.id" @click="pushToUser(u)">


### PR DESCRIPTION
## Summary

Bundles four loosely related improvements that came out of one session.

### Admin → Last Active column
Adds a "Last Active" column to the admin Users grid, derived from the max of: latest review, latest card created, latest deck created, and (new) last login. Rendered as relative time ("3h ago") with full timestamp on hover.

### `AppUser.LastLoginAt` + tracking SignInManager
- New nullable `LastLoginAt` column on `AspNetUsers` (migration `20260517191917_AddAppUserLastLoginAt`).
- `TrackingSignInManager` subclasses `SignInManager<AppUser>` and overrides `SignInWithClaimsAsync` — every sign-in path (password, external, post-register, post-verify) funnels through it, so we capture the timestamp in one place without touching the 5 sign-in call sites.

### MCP `get_overview` → identity
Response now includes an `identity` block (`email`, `displayName`, `externalProvider`) via a new `OverviewService.GetIdentity()`. Lets the AI agent confirm which Fasolt account is connected — useful when juggling multiple test accounts. Kept the lookup in the service layer (no `AppDbContext` in the MCP tool).

### Full-width admin layout
Admin routes now opt out of the 1200px container via route meta `fullWidth: true`. Fixes the horizontal scroll on the user grid. All other pages keep the centered constraint.

### Test pollution cleanup
Discovered that `WebApplicationFactory`-based tests share the dev Postgres DB and were leaking ~430 test users into local development environments. CI is unaffected (fresh container per run), but local dev kept accumulating.
- New `TestUserCleanup` helper deletes users with GUID-pattern emails (`[a-f0-9]{32}`).
- 8 test classes now implement `IAsyncLifetime` and clean up in `DisposeAsync`.
- Regex preserves real users (e.g. `dev@fasolt.local`, `user@icloud.com`).

## Test plan
- [x] `dotnet test` — all 316 tests pass
- [x] Local DB verified clean after test run (only 4 real users remain)
- [x] Restart backend, open Admin → Users, verify "Last Active" column renders
- [x] Verify admin grid no longer scrolls horizontally on wide screens
- [x] Trigger an MCP `get_overview` call and confirm `identity` appears in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)