### PR TITLE
Remove sourceHeading across DB, server, MCP, frontend, iOS, Android

### DIFF
--- a/fasolt.Server/Api/Endpoints/CardEndpoints.cs
+++ b/fasolt.Server/Api/Endpoints/CardEndpoints.cs
@@ -43,7 +43,7 @@ public static class CardEndpoints
 
         try
         {
-            var dto = await cardService.CreateCard(user.Id, request.Front, request.Back, request.SourceFile, request.SourceHeading, request.FrontSvg, request.BackSvg, request.DeckId);
+            var dto = await cardService.CreateCard(user.Id, request.Front, request.Back, request.SourceFile, request.FrontSvg, request.BackSvg, request.DeckId);
             return Results.Created($"/api/cards/{dto.Id}", dto);
         }
         catch (KeyNotFoundException ex)

--- a/fasolt.Server/Api/McpTools/CardTools.cs
+++ b/fasolt.Server/Api/McpTools/CardTools.cs
@@ -18,7 +18,7 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
         return JsonSerializer.Serialize(result, McpJson.Options);
     }
 
-    [McpServerTool, Description("List cards with slim metadata (id, front, back, sourceFile, sourceHeading, isSuspended, decks, createdAt). To pull FSRS scheduling fields or SVG image content across many cards in one call, pass `include`. Do NOT loop over results calling get_card — use include instead. Supports cursor-based pagination via the `after` parameter.")]
+    [McpServerTool, Description("List cards with slim metadata (id, front, back, sourceFile, isSuspended, decks, createdAt). To pull FSRS scheduling fields or SVG image content across many cards in one call, pass `include`. Do NOT loop over results calling get_card — use include instead. Supports cursor-based pagination via the `after` parameter.")]
     public async Task<string> ListCards(
         [Description("Filter by source file name")] string? sourceFile = null,
         [Description("Filter by deck ID")] string? deckId = null,
@@ -104,7 +104,7 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
 
     [McpServerTool, Description("Update one or more existing cards' text or source metadata by cardId. Preserves all review/SRS history.")]
     public async Task<string> UpdateCards(
-        [Description("Array of card updates. Each needs a cardId and at least one field to update (newFront, newBack, newSourceFile, newSourceHeading, newFrontSvg, newBackSvg).")] List<BulkUpdateCardItem> cards)
+        [Description("Array of card updates. Each needs a cardId and at least one field to update (newFront, newBack, newSourceFile, newFrontSvg, newBackSvg).")] List<BulkUpdateCardItem> cards)
     {
         var userId = McpUserResolver.GetUserId(httpContextAccessor);
 

--- a/fasolt.Server/Application/Dtos/AccountDataDtos.cs
+++ b/fasolt.Server/Application/Dtos/AccountDataDtos.cs
@@ -35,7 +35,6 @@ public record AccountExportCard(
     string? FrontSvg,
     string? BackSvg,
     string? SourceFile,
-    string? SourceHeading,
     string State,
     double? Stability,
     double? Difficulty,

--- a/fasolt.Server/Application/Dtos/BulkCardDtos.cs
+++ b/fasolt.Server/Application/Dtos/BulkCardDtos.cs
@@ -9,7 +9,6 @@ public record BulkCardItem(
     [property: Description("Back of the card (answer/explanation). Markdown — see server instructions.")]
     string Back,
     string? SourceFile = null,
-    string? SourceHeading = null,
     [property: Description("Optional inline SVG for the front. See server instructions for sanitization rules and viewBox guidance.")]
     string? FrontSvg = null,
     [property: Description("Optional inline SVG for the back. Same rules as frontSvg.")]

--- a/fasolt.Server/Application/Dtos/CardDtos.cs
+++ b/fasolt.Server/Application/Dtos/CardDtos.cs
@@ -2,17 +2,16 @@ using System.ComponentModel;
 
 namespace Fasolt.Server.Application.Dtos;
 
-public record CreateCardRequest(string? SourceFile, string? SourceHeading, string Front, string Back, string? FrontSvg = null, string? BackSvg = null, string? DeckId = null);
+public record CreateCardRequest(string? SourceFile, string Front, string Back, string? FrontSvg = null, string? BackSvg = null, string? DeckId = null);
 public record UpdateCardRequest(
     string Front,
     string Back,
     string? FrontSvg = null,
     string? BackSvg = null,
     string? SourceFile = null,
-    string? SourceHeading = null,
     List<string>? DeckIds = null);
 public record CardDto(
-    string Id, string? SourceFile, string? SourceHeading,
+    string Id, string? SourceFile,
     string Front, string Back, string? State,
     DateTimeOffset CreatedAt, List<CardDeckInfoDto> Decks,
     bool IsSuspended = false,
@@ -33,7 +32,6 @@ public record UpdateCardFieldsRequest(
     string? NewFront = null,
     string? NewBack = null,
     string? NewSourceFile = null,
-    string? NewSourceHeading = null,
     string? NewFrontSvg = null,
     string? NewBackSvg = null);
 
@@ -54,7 +52,6 @@ public record BulkUpdateCardItem(
     [property: Description("New back of the card. Markdown — see server instructions.")]
     string? NewBack = null,
     string? NewSourceFile = null,
-    string? NewSourceHeading = null,
     [property: Description("New inline SVG for the front. See server instructions.")]
     string? NewFrontSvg = null,
     [property: Description("New inline SVG for the back. Same rules as newFrontSvg.")]

--- a/fasolt.Server/Application/Dtos/DeckDtos.cs
+++ b/fasolt.Server/Application/Dtos/DeckDtos.cs
@@ -12,7 +12,7 @@ public record SetDeckSuspendedRequest(bool IsSuspended);
 
 public record DeckCardDto(
     string Id, string Front, string Back,
-    string? SourceFile, string? SourceHeading,
+    string? SourceFile,
     string State, DateTimeOffset? DueAt,
     bool IsSuspended = false,
     double? Stability = null, double? Difficulty = null,

--- a/fasolt.Server/Application/Dtos/ReviewDtos.cs
+++ b/fasolt.Server/Application/Dtos/ReviewDtos.cs
@@ -6,7 +6,7 @@ public record RateCardResponse(string CardId, double? Stability, double? Difficu
 
 public record DueCardDto(
     string Id, string Front, string Back,
-    string? SourceFile, string? SourceHeading,
+    string? SourceFile,
     string State,
     string? FrontSvg = null, string? BackSvg = null);
 

--- a/fasolt.Server/Application/Dtos/SnapshotDtos.cs
+++ b/fasolt.Server/Application/Dtos/SnapshotDtos.cs
@@ -11,7 +11,6 @@ public record SnapshotCardData(
     string? FrontSvg,
     string? BackSvg,
     string? SourceFile,
-    string? SourceHeading,
     DateTimeOffset CreatedAt,
     double? Stability,
     double? Difficulty,

--- a/fasolt.Server/Application/Services/AccountDataService.cs
+++ b/fasolt.Server/Application/Services/AccountDataService.cs
@@ -83,7 +83,6 @@ public class AccountDataService(AppDbContext db, IOpenIddictTokenManager tokenMa
                 FrontSvg: c.FrontSvg,
                 BackSvg: c.BackSvg,
                 SourceFile: c.SourceFile,
-                SourceHeading: c.SourceHeading,
                 State: c.State,
                 Stability: c.Stability,
                 Difficulty: c.Difficulty,

--- a/fasolt.Server/Application/Services/CardService.cs
+++ b/fasolt.Server/Application/Services/CardService.cs
@@ -11,23 +11,20 @@ public class CardService(AppDbContext db)
 {
     public const int MaxFrontLength = 10_000;
     public const int MaxBackLength = 50_000;
-    public const int MaxSourceHeadingLength = 255;
 
-    public static List<string> ValidateCardFields(string? front, string? back, string? sourceHeading)
+    public static List<string> ValidateCardFields(string? front, string? back)
     {
         var errors = new List<string>();
         if (front is not null && front.Length > MaxFrontLength)
             errors.Add($"Front text exceeds maximum length of {MaxFrontLength} characters.");
         if (back is not null && back.Length > MaxBackLength)
             errors.Add($"Back text exceeds maximum length of {MaxBackLength} characters.");
-        if (sourceHeading is not null && sourceHeading.Length > MaxSourceHeadingLength)
-            errors.Add($"Source heading exceeds maximum length of {MaxSourceHeadingLength} characters.");
         return errors;
     }
 
-    public async Task<CardDto> CreateCard(string userId, string front, string back, string? sourceFile, string? sourceHeading, string? frontSvg = null, string? backSvg = null, string? deckId = null)
+    public async Task<CardDto> CreateCard(string userId, string front, string back, string? sourceFile, string? frontSvg = null, string? backSvg = null, string? deckId = null)
     {
-        var errors = ValidateCardFields(front, back, sourceHeading);
+        var errors = ValidateCardFields(front, back);
         if (errors.Count > 0)
             throw new ValidationException(string.Join(" ", errors));
 
@@ -47,7 +44,6 @@ public class CardService(AppDbContext db)
             PublicId = NanoIdGenerator.New(),
             UserId = userId,
             SourceFile = sourceFile?.Trim(),
-            SourceHeading = sourceHeading,
             Front = front,
             Back = back,
             CreatedAt = DateTimeOffset.UtcNow,
@@ -144,7 +140,7 @@ public class CardService(AppDbContext db)
                 continue;
             }
 
-            var itemErrors = ValidateCardFields(item.Front, item.Back, item.SourceHeading);
+            var itemErrors = ValidateCardFields(item.Front, item.Back);
             if (itemErrors.Count > 0)
             {
                 skipped.Add(new SkippedCardDto(trimmedFront, string.Join(" ", itemErrors)));
@@ -157,7 +153,6 @@ public class CardService(AppDbContext db)
                 PublicId = NanoIdGenerator.New(),
                 UserId = userId,
                 SourceFile = effectiveSourceFile,
-                SourceHeading = item.SourceHeading,
                 Front = trimmedFront,
                 Back = item.Back.Trim(),
                 CreatedAt = DateTimeOffset.UtcNow,
@@ -185,7 +180,7 @@ public class CardService(AppDbContext db)
         await db.SaveChangesAsync();
 
         var createdDtos = created.Select(c => new CardDto(
-            c.PublicId, c.SourceFile, c.SourceHeading, c.Front, c.Back,
+            c.PublicId, c.SourceFile, c.Front, c.Back,
             c.State, c.CreatedAt,
             deckId is not null
                 ? [new CardDeckInfoDto(deckId, "", false)]
@@ -238,7 +233,6 @@ public class CardService(AppDbContext db)
             .Select(c => new CardDto(
                 c.PublicId,
                 c.SourceFile,
-                c.SourceHeading,
                 c.Front,
                 c.Back,
                 includeSrs ? c.State : null,
@@ -278,7 +272,7 @@ public class CardService(AppDbContext db)
 
         if (card is null) return null;
 
-        var errors = ValidateCardFields(request.Front, request.Back, request.SourceHeading);
+        var errors = ValidateCardFields(request.Front, request.Back);
         if (errors.Count > 0)
             throw new ValidationException(string.Join(" ", errors));
 
@@ -290,8 +284,6 @@ public class CardService(AppDbContext db)
             card.BackSvg = request.BackSvg == "" ? null : SvgSanitizer.Sanitize(request.BackSvg);
         if (request.SourceFile is not null)
             card.SourceFile = request.SourceFile == "" ? null : request.SourceFile;
-        if (request.SourceHeading is not null)
-            card.SourceHeading = request.SourceHeading == "" ? null : request.SourceHeading;
 
         if (request.DeckIds is not null)
         {
@@ -331,7 +323,7 @@ public class CardService(AppDbContext db)
 
         foreach (var item in items)
         {
-            var req = new UpdateCardFieldsRequest(item.NewFront, item.NewBack, item.NewSourceFile, item.NewSourceHeading, item.NewFrontSvg, item.NewBackSvg);
+            var req = new UpdateCardFieldsRequest(item.NewFront, item.NewBack, item.NewSourceFile, item.NewFrontSvg, item.NewBackSvg);
             var result = await UpdateCardFields(userId, item.CardId, req);
             results.Add(new BulkUpdateCardResult(item.CardId, result.Status, result.Card));
         }
@@ -344,7 +336,7 @@ public class CardService(AppDbContext db)
         var effectiveFront = req.NewFront?.Trim() ?? card.Front;
         var effectiveSourceFile = req.NewSourceFile?.Trim() ?? card.SourceFile;
 
-        var errors = ValidateCardFields(req.NewFront, req.NewBack, req.NewSourceHeading);
+        var errors = ValidateCardFields(req.NewFront, req.NewBack);
         if (errors.Count > 0)
             throw new ValidationException(string.Join(" ", errors));
 
@@ -367,7 +359,6 @@ public class CardService(AppDbContext db)
         if (req.NewFront is not null) card.Front = req.NewFront.Trim();
         if (req.NewBack is not null) card.Back = req.NewBack.Trim();
         if (req.NewSourceFile is not null) card.SourceFile = req.NewSourceFile.Trim();
-        if (req.NewSourceHeading is not null) card.SourceHeading = req.NewSourceHeading.Trim();
         if (req.NewFrontSvg is not null)
             card.FrontSvg = req.NewFrontSvg == "" ? null : SvgSanitizer.Sanitize(req.NewFrontSvg);
         if (req.NewBackSvg is not null)
@@ -444,7 +435,7 @@ public class CardService(AppDbContext db)
     }
 
     private static CardDto ToDto(Card c) =>
-        new(c.PublicId, c.SourceFile, c.SourceHeading, c.Front, c.Back, c.State, c.CreatedAt,
+        new(c.PublicId, c.SourceFile, c.Front, c.Back, c.State, c.CreatedAt,
             c.DeckCards.Select(dc => new CardDeckInfoDto(dc.Deck.PublicId, dc.Deck.Name, dc.Deck.IsSuspended)).ToList(),
             c.IsSuspended,
             c.DueAt, c.Stability, c.Difficulty, c.Step, c.LastReviewedAt,

--- a/fasolt.Server/Application/Services/DeckService.cs
+++ b/fasolt.Server/Application/Services/DeckService.cs
@@ -56,7 +56,7 @@ public class DeckService(AppDbContext db)
         var cards = await db.DeckCards
             .Where(dc => dc.DeckId == deck.Id)
             .OrderBy(dc => dc.Card.DueAt)
-            .Select(dc => new DeckCardDto(dc.Card.PublicId, dc.Card.Front, dc.Card.Back, dc.Card.SourceFile, dc.Card.SourceHeading, dc.Card.State, dc.Card.DueAt, dc.Card.IsSuspended, dc.Card.Stability, dc.Card.Difficulty, dc.Card.Step, dc.Card.LastReviewedAt, dc.Card.FrontSvg, dc.Card.BackSvg))
+            .Select(dc => new DeckCardDto(dc.Card.PublicId, dc.Card.Front, dc.Card.Back, dc.Card.SourceFile, dc.Card.State, dc.Card.DueAt, dc.Card.IsSuspended, dc.Card.Stability, dc.Card.Difficulty, dc.Card.Step, dc.Card.LastReviewedAt, dc.Card.FrontSvg, dc.Card.BackSvg))
             .ToListAsync();
 
         var dueCount = cards.Count(c => !c.IsSuspended && (c.DueAt == null || c.DueAt <= now));

--- a/fasolt.Server/Application/Services/DeckSnapshotService.cs
+++ b/fasolt.Server/Application/Services/DeckSnapshotService.cs
@@ -46,7 +46,7 @@ public class DeckSnapshotService(AppDbContext db)
                 deck.Description,
                 cards.Select(c => new SnapshotCardData(
                     c.Id, c.PublicId, c.Front, c.Back, c.FrontSvg, c.BackSvg,
-                    c.SourceFile, c.SourceHeading, c.CreatedAt,
+                    c.SourceFile, c.CreatedAt,
                     c.Stability, c.Difficulty, c.Step, c.DueAt, c.State, c.LastReviewedAt,
                     c.IsSuspended
                 )).ToList());
@@ -248,7 +248,6 @@ public class DeckSnapshotService(AppDbContext db)
                     FrontSvg = sc.FrontSvg,
                     BackSvg = sc.BackSvg,
                     SourceFile = sc.SourceFile,
-                    SourceHeading = sc.SourceHeading,
                     CreatedAt = sc.CreatedAt,
                     Stability = sc.Stability,
                     Difficulty = sc.Difficulty,

--- a/fasolt.Server/Application/Services/ReviewService.cs
+++ b/fasolt.Server/Application/Services/ReviewService.cs
@@ -73,7 +73,7 @@ public class ReviewService(AppDbContext db, TimeProvider timeProvider, StudyStat
             .OrderBy(c => c.DueAt ?? DateTimeOffset.MaxValue)
             .ThenBy(c => c.CreatedAt)
             .Take(take)
-            .Select(c => new DueCardDto(c.PublicId, c.Front, c.Back, c.SourceFile, c.SourceHeading, c.State, c.FrontSvg, c.BackSvg))
+            .Select(c => new DueCardDto(c.PublicId, c.Front, c.Back, c.SourceFile, c.State, c.FrontSvg, c.BackSvg))
             .ToListAsync();
     }
 
@@ -84,7 +84,7 @@ public class ReviewService(AppDbContext db, TimeProvider timeProvider, StudyStat
 
         var cards = await db.Cards
             .Where(c => c.UserId == userId && !c.IsSuspended && c.DeckCards.Any(dc => dc.DeckId == deck.Id))
-            .Select(c => new DueCardDto(c.PublicId, c.Front, c.Back, c.SourceFile, c.SourceHeading, c.State, c.FrontSvg, c.BackSvg))
+            .Select(c => new DueCardDto(c.PublicId, c.Front, c.Back, c.SourceFile, c.State, c.FrontSvg, c.BackSvg))
             .ToListAsync();
 
         for (var i = cards.Count - 1; i > 0; i--)

--- a/fasolt.Server/Domain/Entities/Card.cs
+++ b/fasolt.Server/Domain/Entities/Card.cs
@@ -9,7 +9,6 @@ public class Card
     public string UserId { get; set; } = default!;
     public AppUser User { get; set; } = default!;
     public string? SourceFile { get; set; }
-    public string? SourceHeading { get; set; }
     public string Front { get; set; } = default!;
     public string Back { get; set; } = default!;
     public string? FrontSvg { get; set; }

--- a/fasolt.Server/Infrastructure/Data/AppDbContext.cs
+++ b/fasolt.Server/Infrastructure/Data/AppDbContext.cs
@@ -35,7 +35,6 @@ public class AppDbContext : IdentityDbContext<AppUser>, IDataProtectionKeyContex
             entity.Property(e => e.Front).HasMaxLength(10_000).IsRequired();
             entity.Property(e => e.Back).HasMaxLength(50_000).IsRequired();
             entity.Property(e => e.SourceFile).HasMaxLength(255);
-            entity.Property(e => e.SourceHeading).HasMaxLength(255);
             entity.HasIndex(e => e.UserId);
             entity.HasIndex(e => new { e.UserId, e.SourceFile });
 

--- a/fasolt.Server/Infrastructure/Data/DevSeedData.cs
+++ b/fasolt.Server/Infrastructure/Data/DevSeedData.cs
@@ -289,7 +289,6 @@ public static class DevSeedData
             Front = "What is the speed of light?",
             Back = "Approximately 300,000 km/s (299,792,458 m/s) in a vacuum.",
             SourceFile = "physics-notes.md",
-            SourceHeading = "Constants",
             State = "new",
             CreatedAt = now.AddDays(-4),
         };
@@ -303,7 +302,6 @@ public static class DevSeedData
             Front = "What is photosynthesis?",
             Back = "The process by which plants convert sunlight, water, and carbon dioxide into glucose and oxygen. Occurs primarily in chloroplasts.",
             SourceFile = "biology-notes.md",
-            SourceHeading = "Plant Processes",
             State = "new",
             CreatedAt = now.AddDays(-6),
         };
@@ -331,7 +329,6 @@ public static class DevSeedData
             Front = "What does **bold** text look like?",
             Back = "**Bold text** is rendered with a heavier font weight.\n\nYou can also use __double underscores__ for bold.",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Bold",
             State = "new",
             CreatedAt = now,
         };
@@ -344,7 +341,6 @@ public static class DevSeedData
             Front = "How do you write *italic* text?",
             Back = "Use *single asterisks* or _single underscores_ for _italic_ text.",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Italic",
             State = "new",
             CreatedAt = now,
         };
@@ -357,7 +353,6 @@ public static class DevSeedData
             Front = "What does `inline code` look like in markdown?",
             Back = "Wrap text in `backticks` to render it as inline code, e.g. `console.log()` or `git status`.",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Inline Code",
             State = "new",
             CreatedAt = now,
         };
@@ -370,7 +365,6 @@ public static class DevSeedData
             Front = "## Code Blocks\n\nHow do you write a fenced code block?",
             Back = "Use triple backticks with an optional language:\n\n```python\ndef hello():\n    print(\"Hello, world!\")\n```\n\nThis enables syntax highlighting.",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Code Blocks",
             State = "new",
             CreatedAt = now,
         };
@@ -383,7 +377,6 @@ public static class DevSeedData
             Front = "# Heading Levels\n\nHow many heading levels does markdown support?",
             Back = "Six levels:\n\n# Heading 1\n## Heading 2\n### Heading 3\n#### Heading 4\n##### Heading 5\n###### Heading 6",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Headings",
             State = "new",
             CreatedAt = now,
         };
@@ -396,7 +389,6 @@ public static class DevSeedData
             Front = "### Unordered Lists\n\nName three **benefits** of spaced repetition",
             Back = "- Improved long-term retention\n- Efficient use of study time\n- Reduced cramming before exams\n- Builds on the spacing effect from cognitive psychology",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Unordered Lists",
             State = "new",
             CreatedAt = now,
         };
@@ -409,7 +401,6 @@ public static class DevSeedData
             Front = "What are the steps to create a **pull request**?",
             Back = "1. Create a feature branch\n2. Make your changes and commit\n3. Push the branch to the remote\n4. Open a PR on GitHub\n5. Request reviews and address feedback\n6. Merge when approved",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Ordered Lists",
             State = "new",
             CreatedAt = now,
         };
@@ -422,7 +413,6 @@ public static class DevSeedData
             Front = "How do you create a [link](https://example.com) in markdown?",
             Back = "Use `[text](url)` syntax:\n\n[Fasolt on GitHub](https://github.com/fasolt)\n\nThe text in brackets is displayed, the URL in parentheses is the target.",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Links",
             State = "new",
             CreatedAt = now,
         };
@@ -435,7 +425,6 @@ public static class DevSeedData
             Front = "How do you write a blockquote?",
             Back = "> The only way to do great work is to love what you do.\n>\n> — Steve Jobs\n\nPrefix lines with `>` to create a blockquote.",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Blockquotes",
             State = "new",
             CreatedAt = now,
         };
@@ -448,7 +437,6 @@ public static class DevSeedData
             Front = "How do you ~~cross out~~ text?",
             Back = "Wrap text in ~~double tildes~~ to render ~~strikethrough~~ text.",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Strikethrough",
             State = "new",
             CreatedAt = now,
         };
@@ -461,7 +449,6 @@ public static class DevSeedData
             Front = "## Mixed **Markdown** with `code`\n\nWhat happens when you _combine_ formats?",
             Back = "You can **freely** combine:\n\n- **Bold** and *italic* and ~~strikethrough~~\n- `Inline code` within **bold text**\n- Links like [this one](https://example.com) in lists\n\n> Even **blockquotes** can contain *formatted* text and `code`.\n\n```\nAnd code blocks stand alone\n```",
             SourceFile = "markdown-guide.md",
-            SourceHeading = "Mixed Formatting",
             State = "new",
             CreatedAt = now,
         };

--- a/fasolt.Server/Infrastructure/Data/DevSeedHistory.cs
+++ b/fasolt.Server/Infrastructure/Data/DevSeedHistory.cs
@@ -81,7 +81,6 @@ public static class DevSeedHistory
                 FrontSvg = spec.FrontSvg,
                 BackSvg = spec.BackSvg,
                 SourceFile = "visual-notes.md",
-                SourceHeading = spec.Heading,
                 State = "new",
                 CreatedAt = now.AddDays(-ageDays).AddMinutes(rng.Next(0, 24 * 60)),
             };

--- a/fasolt.Server/Infrastructure/Data/Migrations/20260519053021_RemoveSourceHeading.Designer.cs
+++ b/fasolt.Server/Infrastructure/Data/Migrations/20260519053021_RemoveSourceHeading.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fasolt.Server.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Fasolt.Server.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519053021_RemoveSourceHeading")]
+    partial class RemoveSourceHeading
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/fasolt.Server/Infrastructure/Data/Migrations/20260519053021_RemoveSourceHeading.cs
+++ b/fasolt.Server/Infrastructure/Data/Migrations/20260519053021_RemoveSourceHeading.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fasolt.Server.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveSourceHeading : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SourceHeading",
+                table: "Cards");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SourceHeading",
+                table: "Cards",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+        }
+    }
+}

--- a/fasolt.Server/Program.cs
+++ b/fasolt.Server/Program.cs
@@ -378,8 +378,8 @@ builder.Services.AddMcpServer(options =>
     {
         options.ServerInstructions = """
             Fasolt is a spaced-repetition flashcard app. Use these tools to create and
-            manage cards — either extracted from the user's notes (with sourceFile /
-            sourceHeading provenance) or generated directly. Users review the resulting
+            manage cards — either extracted from the user's notes (with sourceFile
+            provenance) or generated directly. Users review the resulting
             cards on the web/iOS app.
 
             # Card text format

--- a/fasolt.Tests/AccountDataServiceTests.cs
+++ b/fasolt.Tests/AccountDataServiceTests.cs
@@ -115,7 +115,6 @@ public class AccountDataServiceTests : IAsyncLifetime
                 Front = "What is X?",
                 Back = "X is Y.",
                 SourceFile = "notes.md",
-                SourceHeading = "Intro",
                 State = "new",
                 CreatedAt = DateTimeOffset.UtcNow,
             };

--- a/fasolt.Tests/CardServiceTests.cs
+++ b/fasolt.Tests/CardServiceTests.cs
@@ -20,10 +20,9 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var card = await svc.CreateCard(UserId, "What is X?", "X is Y.", "notes.md", "Introduction");
+        var card = await svc.CreateCard(UserId, "What is X?", "X is Y.", "notes.md");
 
         card.SourceFile.Should().Be("notes.md");
-        card.SourceHeading.Should().Be("Introduction");
         card.Front.Should().Be("What is X?");
         card.Back.Should().Be("X is Y.");
     }
@@ -36,7 +35,7 @@ public class CardServiceTests : IAsyncLifetime
         var deckSvc = new DeckService(db);
 
         var deck = await deckSvc.CreateDeck(UserId, "Target Deck", null);
-        var card = await cardSvc.CreateCard(UserId, "Q?", "A.", null, null, deckId: deck.Id);
+        var card = await cardSvc.CreateCard(UserId, "Q?", "A.", null, deckId: deck.Id);
 
         card.Decks.Should().ContainSingle(d => d.Id == deck.Id);
     }
@@ -47,7 +46,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var act = () => svc.CreateCard(UserId, "Q?", "A.", null, null, deckId: "nonexistent");
+        var act = () => svc.CreateCard(UserId, "Q?", "A.", null, deckId: "nonexistent");
 
         await act.Should().ThrowAsync<KeyNotFoundException>();
     }
@@ -58,7 +57,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var card = await svc.CreateCard(UserId, "Capital of France?", "Paris", null, null);
+        var card = await svc.CreateCard(UserId, "Capital of France?", "Paris", null);
 
         card.SourceFile.Should().BeNull();
         card.Front.Should().Be("Capital of France?");
@@ -70,8 +69,8 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        await svc.CreateCard(UserId, "Front A", "Back A", "file-a.md", null);
-        await svc.CreateCard(UserId, "Front B", "Back B", "file-b.md", null);
+        await svc.CreateCard(UserId, "Front A", "Back A", "file-a.md");
+        await svc.CreateCard(UserId, "Front B", "Back B", "file-b.md");
 
         var result = await svc.ListCards(UserId, sourceFile: "file-a.md", deckId: null, limit: null, after: null);
 
@@ -87,7 +86,7 @@ public class CardServiceTests : IAsyncLifetime
         var deckSvc = new DeckService(db);
 
         var deck = await deckSvc.CreateDeck(UserId, "Test Deck", null);
-        var card = await cardSvc.CreateCard(UserId, "Deck Q?", "Deck A.", null, null);
+        var card = await cardSvc.CreateCard(UserId, "Deck Q?", "Deck A.", null);
         await deckSvc.AddCards(UserId, deck.Id, [card.Id]);
 
         var result = await cardSvc.ListCards(UserId, sourceFile: null, deckId: deck.Id, limit: null, after: null);
@@ -101,7 +100,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        await svc.CreateCard(UserId, "Q with svg", "A with svg", "slim.md", null,
+        await svc.CreateCard(UserId, "Q with svg", "A with svg", "slim.md",
             frontSvg: "<svg><rect/></svg>", backSvg: "<svg><circle/></svg>");
 
         var result = await svc.ListCards(UserId, sourceFile: "slim.md", deckId: null,
@@ -126,7 +125,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        await svc.CreateCard(UserId, "Q srs", "A srs", "srs.md", null,
+        await svc.CreateCard(UserId, "Q srs", "A srs", "srs.md",
             frontSvg: "<svg/>", backSvg: "<svg/>");
 
         var result = await svc.ListCards(UserId, sourceFile: "srs.md", deckId: null,
@@ -144,7 +143,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        await svc.CreateCard(UserId, "Q svg", "A svg", "svg.md", null,
+        await svc.CreateCard(UserId, "Q svg", "A svg", "svg.md",
             frontSvg: "<svg><rect/></svg>", backSvg: "<svg><circle/></svg>");
 
         var result = await svc.ListCards(UserId, sourceFile: "svg.md", deckId: null,
@@ -163,7 +162,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        await svc.CreateCard(UserId, "Q rest", "A rest", "rest.md", null,
+        await svc.CreateCard(UserId, "Q rest", "A rest", "rest.md",
             frontSvg: "<svg/>", backSvg: "<svg/>");
 
         var result = await svc.ListCards(UserId, sourceFile: "rest.md", deckId: null,
@@ -243,7 +242,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var card = await svc.CreateCard(UserId, "To delete", "Gone", null, null);
+        var card = await svc.CreateCard(UserId, "To delete", "Gone", null);
 
         var deleted = await svc.DeleteCard(UserId, card.Id);
         deleted.Should().BeTrue();
@@ -258,9 +257,9 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var a = await svc.CreateCard(UserId, "A", "A", null, null);
-        var b = await svc.CreateCard(UserId, "B", "B", null, null);
-        var c = await svc.CreateCard(UserId, "C", "C", null, null);
+        var a = await svc.CreateCard(UserId, "A", "A", null);
+        var b = await svc.CreateCard(UserId, "B", "B", null);
+        var c = await svc.CreateCard(UserId, "C", "C", null);
 
         var count = await svc.DeleteCards(UserId, [a.Id, b.Id]);
 
@@ -276,7 +275,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var card = await svc.CreateCard(UserId, "Old front", "Old back", "notes.md", "Heading");
+        var card = await svc.CreateCard(UserId, "Old front", "Old back", "notes.md");
 
         // Simulate some SRS state by updating directly
         var entity = await db.Cards.FirstOrDefaultAsync(c => c.PublicId == card.Id);
@@ -308,8 +307,8 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        await svc.CreateCard(UserId, "Existing front", "Back A", "notes.md", null);
-        var cardB = await svc.CreateCard(UserId, "Other front", "Back B", "notes.md", null);
+        await svc.CreateCard(UserId, "Existing front", "Back A", "notes.md");
+        var cardB = await svc.CreateCard(UserId, "Other front", "Back B", "notes.md");
 
         // Try to rename cardB's front to collide with existing card
         var result = await svc.UpdateCardFields(UserId, cardB.Id,
@@ -325,8 +324,8 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        await svc.CreateCard(UserId, "Same front", "Back A", "notes.md", null);
-        var cardB = await svc.CreateCard(UserId, "Same front", "Back B", "other.md", null);
+        await svc.CreateCard(UserId, "Same front", "Back A", "notes.md");
+        var cardB = await svc.CreateCard(UserId, "Same front", "Back B", "other.md");
 
         // Move cardB to notes.md — collides with existing card
         var result = await svc.UpdateCardFields(UserId, cardB.Id,
@@ -343,7 +342,7 @@ public class CardServiceTests : IAsyncLifetime
 
         // Create 5 cards
         for (var i = 1; i <= 5; i++)
-            await svc.CreateCard(UserId, $"Page {i}", $"Back {i}", "page.md", null);
+            await svc.CreateCard(UserId, $"Page {i}", $"Back {i}", "page.md");
 
         var page1 = await svc.ListCards(UserId, sourceFile: null, deckId: null, limit: 2, after: null);
 
@@ -372,7 +371,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var card = await svc.CreateCard(UserId, "Reset Q", "Reset A", null, null);
+        var card = await svc.CreateCard(UserId, "Reset Q", "Reset A", null);
 
         // Simulate SRS state
         var entity = await db.Cards.FindAsync(db.Cards.First(c => c.PublicId == card.Id).Id);
@@ -412,8 +411,8 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var a = await svc.CreateCard(UserId, "BU-A", "Old A", "bulk.md", null);
-        var b = await svc.CreateCard(UserId, "BU-B", "Old B", "bulk.md", null);
+        var a = await svc.CreateCard(UserId, "BU-A", "Old A", "bulk.md");
+        var b = await svc.CreateCard(UserId, "BU-B", "Old B", "bulk.md");
 
         var results = await svc.BulkUpdateCards(UserId,
         [
@@ -433,7 +432,7 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        var card = await svc.CreateCard(UserId, "Exists", "Back", "mix.md", null);
+        var card = await svc.CreateCard(UserId, "Exists", "Back", "mix.md");
 
         var results = await svc.BulkUpdateCards(UserId,
         [
@@ -452,9 +451,9 @@ public class CardServiceTests : IAsyncLifetime
         await using var db = _db.CreateDbContext();
         var svc = new CardService(db);
 
-        await svc.CreateCard(UserId, "Q1", "A1", "target.md", null);
-        await svc.CreateCard(UserId, "Q2", "A2", "target.md", null);
-        await svc.CreateCard(UserId, "Q3", "A3", "other.md", null);
+        await svc.CreateCard(UserId, "Q1", "A1", "target.md");
+        await svc.CreateCard(UserId, "Q2", "A2", "target.md");
+        await svc.CreateCard(UserId, "Q3", "A3", "other.md");
 
         var count = await svc.DeleteCardsBySource(UserId, "target.md");
 
@@ -484,7 +483,7 @@ public class CardServiceTests : IAsyncLifetime
 
         var longFront = new string('x', CardService.MaxFrontLength + 1);
 
-        var act = () => svc.CreateCard(UserId, longFront, "Back", null, null);
+        var act = () => svc.CreateCard(UserId, longFront, "Back", null);
 
         await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>()
             .WithMessage("*Front*maximum*");
@@ -498,24 +497,10 @@ public class CardServiceTests : IAsyncLifetime
 
         var longBack = new string('x', CardService.MaxBackLength + 1);
 
-        var act = () => svc.CreateCard(UserId, "Front", longBack, null, null);
+        var act = () => svc.CreateCard(UserId, "Front", longBack, null);
 
         await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>()
             .WithMessage("*Back*maximum*");
-    }
-
-    [Fact]
-    public async Task CreateCard_RejectsOversizedSourceHeading()
-    {
-        await using var db = _db.CreateDbContext();
-        var svc = new CardService(db);
-
-        var longHeading = new string('x', CardService.MaxSourceHeadingLength + 1);
-
-        var act = () => svc.CreateCard(UserId, "Front", "Back", "file.md", longHeading);
-
-        await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>()
-            .WithMessage("*Source heading*maximum*");
     }
 
     [Fact]
@@ -526,13 +511,11 @@ public class CardServiceTests : IAsyncLifetime
 
         var front = new string('x', CardService.MaxFrontLength);
         var back = new string('x', CardService.MaxBackLength);
-        var heading = new string('x', CardService.MaxSourceHeadingLength);
 
-        var card = await svc.CreateCard(UserId, front, back, "file.md", heading);
+        var card = await svc.CreateCard(UserId, front, back, "file.md");
 
         card.Front.Should().HaveLength(CardService.MaxFrontLength);
         card.Back.Should().HaveLength(CardService.MaxBackLength);
-        card.SourceHeading.Should().HaveLength(CardService.MaxSourceHeadingLength);
     }
 
     [Fact]

--- a/fasolt.Tests/DeckServiceTests.cs
+++ b/fasolt.Tests/DeckServiceTests.cs
@@ -49,7 +49,7 @@ public class DeckServiceTests : IAsyncLifetime
         var deckSvc = new DeckService(db);
 
         var deck = await deckSvc.CreateDeck(UserId, "Detail Deck", null);
-        var card = await cardSvc.CreateCard(UserId, "Card Q?", "Card A.", "source.md", "## Section");
+        var card = await cardSvc.CreateCard(UserId, "Card Q?", "Card A.", "source.md");
         await deckSvc.AddCards(UserId, deck.Id, [card.Id]);
 
         var detail = await deckSvc.GetDeck(UserId, deck.Id);
@@ -57,7 +57,6 @@ public class DeckServiceTests : IAsyncLifetime
         detail.Should().NotBeNull();
         detail!.Cards.Should().HaveCount(1);
         detail.Cards[0].SourceFile.Should().Be("source.md");
-        detail.Cards[0].SourceHeading.Should().Be("## Section");
     }
 
     [Fact]

--- a/fasolt.Tests/DeckSnapshotServiceTests.cs
+++ b/fasolt.Tests/DeckSnapshotServiceTests.cs
@@ -103,7 +103,7 @@ public class DeckSnapshotServiceTests : IAsyncLifetime
         var deckSvc = new DeckService(db);
 
         var deck = await deckSvc.CreateDeck(UserId, "Field Test", "Test desc");
-        var card = await cardSvc.CreateCard(UserId, "Front", "Back", "source.md", "## Heading");
+        var card = await cardSvc.CreateCard(UserId, "Front", "Back", "source.md");
         await deckSvc.AddCards(UserId, deck.Id, [card.Id]);
 
         // Set FSRS and suspension state on the card entity directly
@@ -132,7 +132,6 @@ public class DeckSnapshotServiceTests : IAsyncLifetime
         sc.Front.Should().Be("Front");
         sc.Back.Should().Be("Back");
         sc.SourceFile.Should().Be("source.md");
-        sc.SourceHeading.Should().Be("## Heading");
         sc.Stability.Should().Be(12.5);
         sc.Difficulty.Should().Be(0.3);
         sc.Step.Should().Be(2);
@@ -734,12 +733,11 @@ public class DeckSnapshotServiceTests : IAsyncLifetime
             await svc.CreateAll(UserId);
         }
 
-        // Change only sourceFile and sourceHeading
+        // Change only sourceFile
         await using (var db = _db.CreateDbContext())
         {
             var card = db.Cards.First(c => c.UserId == UserId);
             card.SourceFile = "new-source.md";
-            card.SourceHeading = "## New Heading";
             await db.SaveChangesAsync();
         }
 
@@ -1270,7 +1268,6 @@ public class DeckSnapshotServiceTests : IAsyncLifetime
             var card = db.Cards.First(c => c.UserId == UserId);
             card.Front = "Changed front";
             card.SourceFile = "new-source.md";
-            card.SourceHeading = "## New Section";
             await db.SaveChangesAsync();
         }
 
@@ -1287,7 +1284,6 @@ public class DeckSnapshotServiceTests : IAsyncLifetime
         var restored = checkDb.Cards.First(c => c.UserId == UserId);
         restored.Front.Should().Be("Restore KeepSource Q0", "content should be reverted");
         restored.SourceFile.Should().Be("new-source.md", "source metadata should NOT be reverted");
-        restored.SourceHeading.Should().Be("## New Section", "source metadata should NOT be reverted");
     }
 
     [Fact]

--- a/fasolt.android/app/src/main/java/com/fasolt/android/data/api/models/Models.kt
+++ b/fasolt.android/app/src/main/java/com/fasolt/android/data/api/models/Models.kt
@@ -53,7 +53,6 @@ data class DeckCardDto(
     val front: String,
     val back: String,
     val sourceFile: String? = null,
-    val sourceHeading: String? = null,
     val state: String,
     val dueAt: String? = null,
     val isSuspended: Boolean,
@@ -82,7 +81,6 @@ data class CardDto(
     val front: String,
     val back: String,
     val sourceFile: String? = null,
-    val sourceHeading: String? = null,
     val state: String,
     val dueAt: String? = null,
     val stability: Double? = null,
@@ -104,7 +102,6 @@ data class CreateCardRequest(
     val front: String,
     val back: String,
     val sourceFile: String? = null,
-    val sourceHeading: String? = null,
     val deckId: String? = null,
 )
 
@@ -113,7 +110,6 @@ data class UpdateCardRequest(
     val front: String,
     val back: String,
     val sourceFile: String? = null,
-    val sourceHeading: String? = null,
     val deckIds: List<String>? = null,
 )
 
@@ -125,7 +121,6 @@ data class DueCardDto(
     val front: String,
     val back: String,
     val sourceFile: String? = null,
-    val sourceHeading: String? = null,
     val state: String,
     val frontSvg: String? = null,
     val backSvg: String? = null,

--- a/fasolt.android/app/src/main/java/com/fasolt/android/data/cards/CardRepository.kt
+++ b/fasolt.android/app/src/main/java/com/fasolt/android/data/cards/CardRepository.kt
@@ -21,18 +21,16 @@ class CardRepository(private val api: FasoltApi) {
         front: String,
         back: String,
         sourceFile: String? = null,
-        sourceHeading: String? = null,
         deckId: String? = null,
-    ): CardDto = api.createCard(CreateCardRequest(front, back, sourceFile, sourceHeading, deckId))
+    ): CardDto = api.createCard(CreateCardRequest(front, back, sourceFile, deckId))
 
     suspend fun update(
         id: String,
         front: String,
         back: String,
         sourceFile: String? = null,
-        sourceHeading: String? = null,
         deckIds: List<String>? = null,
-    ): CardDto = api.updateCard(id, UpdateCardRequest(front, back, sourceFile, sourceHeading, deckIds))
+    ): CardDto = api.updateCard(id, UpdateCardRequest(front, back, sourceFile, deckIds))
 
     suspend fun delete(id: String) = api.deleteCard(id)
 

--- a/fasolt.android/app/src/main/java/com/fasolt/android/ui/cards/CardFormScreen.kt
+++ b/fasolt.android/app/src/main/java/com/fasolt/android/ui/cards/CardFormScreen.kt
@@ -77,7 +77,6 @@ fun CardFormScreen(
     var front by remember { mutableStateOf("") }
     var back by remember { mutableStateOf("") }
     var sourceFile by remember { mutableStateOf("") }
-    var sourceHeading by remember { mutableStateOf("") }
     val selectedDeckIds: SnapshotStateList<String> = remember { mutableListOf<String>().toMutableStateList() }
     var initialized by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -89,7 +88,6 @@ fun CardFormScreen(
                 front = c.front
                 back = c.back
                 sourceFile = c.sourceFile.orEmpty()
-                sourceHeading = c.sourceHeading.orEmpty()
                 selectedDeckIds.clear()
                 selectedDeckIds.addAll(c.decks.map { it.id })
             }
@@ -130,7 +128,6 @@ fun CardFormScreen(
                                 front = front.trim(),
                                 back = back.trim(),
                                 sourceFile = sourceFile.trim().ifEmpty { null },
-                                sourceHeading = sourceHeading.trim().ifEmpty { null },
                                 deckIds = selectedDeckIds.toList(),
                             ) { success -> if (success) onNavigateBack() }
                         },
@@ -176,13 +173,6 @@ fun CardFormScreen(
                         value = sourceFile,
                         onValueChange = { sourceFile = it },
                         label = { Text("Source file") },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    OutlinedTextField(
-                        value = sourceHeading,
-                        onValueChange = { sourceHeading = it },
-                        label = { Text("Heading") },
                         singleLine = true,
                         modifier = Modifier.fillMaxWidth(),
                     )

--- a/fasolt.android/app/src/main/java/com/fasolt/android/ui/cards/CardFormViewModel.kt
+++ b/fasolt.android/app/src/main/java/com/fasolt/android/ui/cards/CardFormViewModel.kt
@@ -73,7 +73,6 @@ class CardFormViewModel(
         front: String,
         back: String,
         sourceFile: String?,
-        sourceHeading: String?,
         deckIds: List<String>,
         onDone: (Boolean) -> Unit,
     ) {
@@ -88,7 +87,6 @@ class CardFormViewModel(
                         front = front,
                         back = back,
                         sourceFile = sourceFile,
-                        sourceHeading = sourceHeading,
                         deckId = deckIds.firstOrNull() ?: initialDeckId,
                     )
                 } else {
@@ -97,7 +95,6 @@ class CardFormViewModel(
                         front = front,
                         back = back,
                         sourceFile = sourceFile,
-                        sourceHeading = sourceHeading,
                         deckIds = deckIds,
                     )
                 }

--- a/fasolt.android/app/src/main/java/com/fasolt/android/ui/study/CardDisplay.kt
+++ b/fasolt.android/app/src/main/java/com/fasolt/android/ui/study/CardDisplay.kt
@@ -36,7 +36,6 @@ fun CardDisplay(
 ) {
     val text = if (isFlipped) card.back else card.front
     val svg = if (isFlipped) card.backSvg else card.frontSvg
-    val sourceHeading = if (isFlipped) card.sourceHeading else null
     // When the answer is showing, repeat the question above as a small hint —
     // matches iOS's CardView questionText behaviour.
     val questionHint = if (isFlipped) card.front else null
@@ -81,15 +80,9 @@ fun CardDisplay(
                 )
             }
 
-            if (!card.sourceFile.isNullOrBlank() || !sourceHeading.isNullOrBlank()) {
+            val source = card.sourceFile
+            if (!source.isNullOrBlank()) {
                 Spacer(Modifier.height(16.dp))
-                val source = buildString {
-                    card.sourceFile?.let { append(it) }
-                    if (!sourceHeading.isNullOrBlank()) {
-                        if (isNotEmpty()) append(" · ")
-                        append(sourceHeading)
-                    }
-                }
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,

--- a/fasolt.client/src/__tests__/stores/cards.test.ts
+++ b/fasolt.client/src/__tests__/stores/cards.test.ts
@@ -14,10 +14,10 @@ function makeCard(overrides: Partial<{
   state: 'new' | 'learning' | 'review' | 'relearning';
   stability: number | null; difficulty: number | null;
   step: number | null; dueAt: string | null; lastReviewedAt: string | null;
-  sourceFile: string | null; sourceHeading: string | null;
+  sourceFile: string | null;
 }> = {}) {
   return {
-    id: 'c1', sourceFile: null, sourceHeading: null,
+    id: 'c1', sourceFile: null,
     front: 'Q', back: 'A', frontSvg: null, backSvg: null,
     createdAt: '2024-01-01T00:00:00Z',
     stability: null, difficulty: null, step: null, dueAt: null,
@@ -106,7 +106,6 @@ describe('cards store', () => {
     const store = useCardsStore()
     const result = await store.createCard({
       sourceFile: 'notes.md',
-      sourceHeading: '## CAP Theorem',
       front: 'Q',
       back: 'A',
     })
@@ -115,7 +114,6 @@ describe('cards store', () => {
       method: 'POST',
       body: JSON.stringify({
         sourceFile: 'notes.md',
-        sourceHeading: '## CAP Theorem',
         front: 'Q',
         back: 'A',
       }),

--- a/fasolt.client/src/__tests__/stores/review.test.ts
+++ b/fasolt.client/src/__tests__/stores/review.test.ts
@@ -17,7 +17,7 @@ describe('review store', () => {
 
   it('starts a session by fetching due cards', async () => {
     const mockCards = [
-      { id: 'c1', front: 'What is CAP?', back: 'Consistency, Availability, Partition tolerance', sourceFile: 'cap.md', sourceHeading: '## Overview', state: 'learning' },
+      { id: 'c1', front: 'What is CAP?', back: 'Consistency, Availability, Partition tolerance', sourceFile: 'cap.md', state: 'learning' },
     ]
     mockApiFetch.mockResolvedValueOnce(mockCards)
 
@@ -30,7 +30,7 @@ describe('review store', () => {
 
   it('flips the current card', async () => {
     mockApiFetch.mockResolvedValueOnce([
-      { id: 'c1', front: 'Q', back: 'A', sourceFile: null, sourceHeading: null, state: 'new' },
+      { id: 'c1', front: 'Q', back: 'A', sourceFile: null, state: 'new' },
     ])
 
     const store = useReviewStore()
@@ -43,8 +43,8 @@ describe('review store', () => {
 
   it('rates a card and advances to next', async () => {
     mockApiFetch.mockResolvedValueOnce([
-      { id: 'c1', front: 'Q1', back: 'A1', sourceFile: null, sourceHeading: null, state: 'new' },
-      { id: 'c2', front: 'Q2', back: 'A2', sourceFile: null, sourceHeading: null, state: 'new' },
+      { id: 'c1', front: 'Q1', back: 'A1', sourceFile: null, state: 'new' },
+      { id: 'c2', front: 'Q2', back: 'A2', sourceFile: null, state: 'new' },
     ])
     mockApiFetch.mockResolvedValueOnce({ cardId: 'c1', stability: 1.0, difficulty: 5.0, dueAt: null, state: 'learning' })
 
@@ -59,7 +59,7 @@ describe('review store', () => {
 
   it('completes session after rating last card', async () => {
     mockApiFetch.mockResolvedValueOnce([
-      { id: 'c1', front: 'Q1', back: 'A1', sourceFile: null, sourceHeading: null, state: 'new' },
+      { id: 'c1', front: 'Q1', back: 'A1', sourceFile: null, state: 'new' },
     ])
     mockApiFetch.mockResolvedValueOnce({ cardId: 'c1', stability: 1.0, difficulty: 5.0, dueAt: null, state: 'learning' })
 
@@ -95,7 +95,7 @@ describe('review store', () => {
 
   it('rate sends correct API request', async () => {
     mockApiFetch.mockResolvedValueOnce([
-      { id: 'c1', front: 'Q', back: 'A', sourceFile: null, sourceHeading: null, state: 'new', frontSvg: null, backSvg: null },
+      { id: 'c1', front: 'Q', back: 'A', sourceFile: null, state: 'new', frontSvg: null, backSvg: null },
     ])
 
     const store = useReviewStore()
@@ -116,7 +116,7 @@ describe('review store', () => {
 
   it('rate again re-enqueues the card', async () => {
     mockApiFetch.mockResolvedValueOnce([
-      { id: 'c1', front: 'Q', back: 'A', sourceFile: null, sourceHeading: null, state: 'new', frontSvg: null, backSvg: null },
+      { id: 'c1', front: 'Q', back: 'A', sourceFile: null, state: 'new', frontSvg: null, backSvg: null },
     ])
 
     const store = useReviewStore()

--- a/fasolt.client/src/components/CardCreateDialog.vue
+++ b/fasolt.client/src/components/CardCreateDialog.vue
@@ -10,7 +10,6 @@ import {
 const props = defineProps<{
   open: boolean
   sourceFile?: string
-  sourceHeading?: string
   initialFronts?: string[]
   initialBack?: string
 }>()
@@ -26,7 +25,6 @@ const { render } = useMarkdown()
 const fronts = ref<string[]>([])
 const back = ref('')
 const sourceFile = ref('')
-const sourceHeading = ref('')
 const saving = ref(false)
 const error = ref('')
 const showPreview = ref(false)
@@ -36,7 +34,6 @@ watch(() => props.open, (isOpen) => {
     fronts.value = props.initialFronts?.length ? [...props.initialFronts] : ['']
     back.value = props.initialBack ?? ''
     sourceFile.value = props.sourceFile ?? ''
-    sourceHeading.value = props.sourceHeading ?? ''
     error.value = ''
     showPreview.value = false
   }
@@ -63,7 +60,6 @@ async function save() {
     for (const front of validFronts) {
       await cards.createCard({
         sourceFile: sourceFile.value.trim() || undefined,
-        sourceHeading: sourceHeading.value.trim() || undefined,
         front,
         back: back.value,
       })
@@ -87,25 +83,14 @@ async function save() {
 
       <div class="space-y-4">
         <!-- Source metadata -->
-        <div class="grid grid-cols-2 gap-3">
-          <div class="space-y-1">
-            <label class="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.1em]">Source file</label>
-            <input
-              v-model="sourceFile"
-              type="text"
-              placeholder="e.g. distributed-systems.md"
-              class="w-full rounded border border-border bg-transparent px-3 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-            />
-          </div>
-          <div class="space-y-1">
-            <label class="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.1em]">Source heading</label>
-            <input
-              v-model="sourceHeading"
-              type="text"
-              placeholder="e.g. CAP Theorem"
-              class="w-full rounded border border-border bg-transparent px-3 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-            />
-          </div>
+        <div class="space-y-1">
+          <label class="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.1em]">Source file</label>
+          <input
+            v-model="sourceFile"
+            type="text"
+            placeholder="e.g. distributed-systems.md"
+            class="w-full rounded border border-border bg-transparent px-3 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+          />
         </div>
 
         <!-- Single front -->

--- a/fasolt.client/src/components/ReviewCard.vue
+++ b/fasolt.client/src/components/ReviewCard.vue
@@ -33,13 +33,9 @@ function openEdit(cardId: string) {
 
     <header class="card-head">
       <span class="fa-cap card-label">{{ isFlipped ? 'Answer' : 'Question' }}</span>
-      <div v-if="card.sourceFile || card.sourceHeading" class="card-source">
+      <div v-if="card.sourceFile" class="card-source">
         <FileText :size="12" />
-        <span v-if="card.sourceFile" class="fa-mono">{{ card.sourceFile }}</span>
-        <template v-if="card.sourceFile && card.sourceHeading">
-          <span class="card-source-sep">›</span>
-        </template>
-        <span v-if="card.sourceHeading" class="fa-mono card-source-heading">{{ card.sourceHeading }}</span>
+        <span class="fa-mono">{{ card.sourceFile }}</span>
       </div>
     </header>
 

--- a/fasolt.client/src/stores/cards.ts
+++ b/fasolt.client/src/stores/cards.ts
@@ -22,7 +22,6 @@ export const useCardsStore = defineStore('cards', () => {
 
   async function createCard(data: {
     sourceFile?: string
-    sourceHeading?: string
     front: string
     back: string
   }): Promise<Card> {
@@ -39,7 +38,6 @@ export const useCardsStore = defineStore('cards', () => {
     frontSvg?: string | null
     backSvg?: string | null
     sourceFile?: string | null
-    sourceHeading?: string | null
     deckIds?: string[]
   }): Promise<Card> {
     const result = await apiFetch<Card>(`/cards/${id}`, {

--- a/fasolt.client/src/types/index.ts
+++ b/fasolt.client/src/types/index.ts
@@ -1,7 +1,6 @@
 export interface Card {
   id: string
   sourceFile: string | null
-  sourceHeading: string | null
   front: string
   back: string
   frontSvg: string | null
@@ -44,7 +43,6 @@ export interface DeckCard {
   front: string
   back: string
   sourceFile: string | null
-  sourceHeading: string | null
   state: string
   dueAt: string | null
   isSuspended: boolean
@@ -57,7 +55,6 @@ export interface DueCard {
   front: string
   back: string
   sourceFile: string | null
-  sourceHeading: string | null
   state: string
   frontSvg: string | null
   backSvg: string | null

--- a/fasolt.client/src/views/CardDetailView.vue
+++ b/fasolt.client/src/views/CardDetailView.vue
@@ -34,7 +34,6 @@ const back = ref('')
 const editFrontSvg = ref('')
 const editBackSvg = ref('')
 const editSourceFile = ref('')
-const editSourceHeading = ref('')
 const editDeckIds = ref<string[]>([])
 const saving = ref(false)
 const error = ref('')
@@ -141,7 +140,6 @@ function startEdit() {
   editFrontSvg.value = card.value.frontSvg ?? ''
   editBackSvg.value = card.value.backSvg ?? ''
   editSourceFile.value = card.value.sourceFile ?? ''
-  editSourceHeading.value = card.value.sourceHeading ?? ''
   editDeckIds.value = card.value.decks.map(d => d.id)
   error.value = ''
   editing.value = true
@@ -161,7 +159,6 @@ async function save() {
       frontSvg: editFrontSvg.value,
       backSvg: editBackSvg.value,
       sourceFile: editSourceFile.value || null,
-      sourceHeading: editSourceHeading.value || null,
       deckIds: editDeckIds.value,
     })
     editing.value = false
@@ -272,9 +269,8 @@ function onDeleted() {
 
     <!-- Metadata -->
     <div class="space-y-1 text-sm text-muted-foreground">
-      <div v-if="card.sourceFile || card.sourceHeading" class="flex flex-wrap gap-x-6">
-        <span v-if="card.sourceFile">Source: <span class="text-foreground">{{ card.sourceFile }}</span></span>
-        <span v-if="card.sourceHeading">Section: <span class="text-foreground">{{ card.sourceHeading }}</span></span>
+      <div v-if="card.sourceFile" class="flex flex-wrap gap-x-6">
+        <span>Source: <span class="text-foreground">{{ card.sourceFile }}</span></span>
       </div>
       <div v-if="card.decks.length > 0">
         Decks:
@@ -320,15 +316,9 @@ function onDeleted() {
 
     <!-- Edit mode -->
     <div v-if="editing" class="space-y-4">
-      <div class="grid grid-cols-2 gap-3">
-        <div class="space-y-1">
-          <label class="text-[11px] font-medium text-muted-foreground">Source file</label>
-          <Input v-model="editSourceFile" placeholder="e.g. notes.md" class="h-8 text-sm" />
-        </div>
-        <div class="space-y-1">
-          <label class="text-[11px] font-medium text-muted-foreground">Section</label>
-          <Input v-model="editSourceHeading" placeholder="e.g. Chapter 1" class="h-8 text-sm" />
-        </div>
+      <div class="space-y-1">
+        <label class="text-[11px] font-medium text-muted-foreground">Source file</label>
+        <Input v-model="editSourceFile" placeholder="e.g. notes.md" class="h-8 text-sm" />
       </div>
       <div class="space-y-1">
         <label class="text-[11px] font-medium text-muted-foreground">Decks</label>

--- a/fasolt.ios/Fasolt/Models/APIModels.swift
+++ b/fasolt.ios/Fasolt/Models/APIModels.swift
@@ -23,7 +23,6 @@ struct CardDTO: Decodable, Sendable, Identifiable {
     let front: String
     let back: String
     let sourceFile: String?
-    let sourceHeading: String?
     let state: String
     let dueAt: String?
     let stability: Double?
@@ -70,7 +69,6 @@ struct DeckCardDTO: Decodable, Sendable, Identifiable {
     let front: String
     let back: String
     let sourceFile: String?
-    let sourceHeading: String?
     let state: String
     let dueAt: String?
     let isSuspended: Bool
@@ -89,7 +87,6 @@ struct DueCardDTO: Decodable, Sendable {
     let front: String
     let back: String
     let sourceFile: String?
-    let sourceHeading: String?
     let state: String
     let frontSvg: String?
     let backSvg: String?
@@ -217,7 +214,6 @@ struct CreateCardRequest: Encodable, Sendable {
     let front: String
     let back: String
     let sourceFile: String?
-    let sourceHeading: String?
     let deckId: String?
 }
 
@@ -225,7 +221,6 @@ struct UpdateCardRequest: Encodable, Sendable {
     let front: String
     let back: String
     let sourceFile: String?
-    let sourceHeading: String?
     let deckIds: [String]?
 }
 

--- a/fasolt.ios/Fasolt/Models/Card.swift
+++ b/fasolt.ios/Fasolt/Models/Card.swift
@@ -7,7 +7,6 @@ final class Card {
     var front: String
     var back: String
     var sourceFile: String?
-    var sourceHeading: String?
     var state: String
     var dueAt: Date?
     var stability: Double?
@@ -23,7 +22,7 @@ final class Card {
 
     init(
         publicId: String, front: String, back: String,
-        sourceFile: String? = nil, sourceHeading: String? = nil,
+        sourceFile: String? = nil,
         state: String = "new", dueAt: Date? = nil,
         stability: Double? = nil, difficulty: Double? = nil,
         step: Int? = nil, lastReviewedAt: Date? = nil,
@@ -34,7 +33,6 @@ final class Card {
         self.front = front
         self.back = back
         self.sourceFile = sourceFile
-        self.sourceHeading = sourceHeading
         self.state = state
         self.dueAt = dueAt
         self.stability = stability

--- a/fasolt.ios/Fasolt/Repositories/DeckRepository.swift
+++ b/fasolt.ios/Fasolt/Repositories/DeckRepository.swift
@@ -122,7 +122,6 @@ final class DeckRepository {
                 card.front = cardDto.front
                 card.back = cardDto.back
                 card.sourceFile = cardDto.sourceFile
-                card.sourceHeading = cardDto.sourceHeading
                 card.state = cardDto.state
                 card.dueAt = cardDto.dueAt.flatMap { DateFormatters.parseISO8601($0) }
                 card.stability = cardDto.stability
@@ -140,7 +139,6 @@ final class DeckRepository {
                     front: cardDto.front,
                     back: cardDto.back,
                     sourceFile: cardDto.sourceFile,
-                    sourceHeading: cardDto.sourceHeading,
                     state: cardDto.state,
                     dueAt: cardDto.dueAt.flatMap { DateFormatters.parseISO8601( $0) },
                     stability: cardDto.stability,
@@ -189,7 +187,6 @@ final class DeckRepository {
                 front: card.front,
                 back: card.back,
                 sourceFile: card.sourceFile,
-                sourceHeading: card.sourceHeading,
                 state: card.state,
                 dueAt: card.dueAt.map { DateFormatters.formatISO8601( $0) },
                 isSuspended: false,

--- a/fasolt.ios/Fasolt/ViewModels/CardListViewModel.swift
+++ b/fasolt.ios/Fasolt/ViewModels/CardListViewModel.swift
@@ -36,8 +36,7 @@ final class CardListViewModel {
         return result.filter { card in
             card.front.localizedCaseInsensitiveContains(query) ||
             card.back.localizedCaseInsensitiveContains(query) ||
-            (card.sourceFile?.localizedCaseInsensitiveContains(query) ?? false) ||
-            (card.sourceHeading?.localizedCaseInsensitiveContains(query) ?? false)
+            (card.sourceFile?.localizedCaseInsensitiveContains(query) ?? false)
         }
     }
 
@@ -88,7 +87,6 @@ final class CardListViewModel {
             front: request.front,
             back: request.back,
             sourceFile: request.sourceFile,
-            sourceHeading: request.sourceHeading,
             deckId: deckId
         )
         _ = try await cardRepository.createCard(finalRequest)

--- a/fasolt.ios/Fasolt/ViewModels/DeckDetailViewModel.swift
+++ b/fasolt.ios/Fasolt/ViewModels/DeckDetailViewModel.swift
@@ -77,7 +77,6 @@ final class DeckDetailViewModel {
             front: request.front,
             back: request.back,
             sourceFile: request.sourceFile,
-            sourceHeading: request.sourceHeading,
             deckId: deckId
         )
         _ = try await cardRepository.createCard(finalRequest)

--- a/fasolt.ios/Fasolt/Views/Cards/CardFormSheet.swift
+++ b/fasolt.ios/Fasolt/Views/Cards/CardFormSheet.swift
@@ -11,7 +11,6 @@ struct CardFormSheet: View {
     @State private var front = ""
     @State private var back = ""
     @State private var sourceFile = ""
-    @State private var sourceHeading = ""
     @State private var selectedDeckIds: Set<String> = []
     @State private var isSuspended = false
     @State private var isSaving = false
@@ -19,7 +18,7 @@ struct CardFormSheet: View {
 
     enum Mode {
         case create(initialDeckIds: [String] = [])
-        case edit(front: String, back: String, sourceFile: String?, sourceHeading: String?, deckIds: [String], isSuspended: Bool)
+        case edit(front: String, back: String, sourceFile: String?, deckIds: [String], isSuspended: Bool)
 
         var title: String {
             switch self {
@@ -43,11 +42,10 @@ struct CardFormSheet: View {
         switch mode {
         case .create(let initialDeckIds):
             _selectedDeckIds = State(initialValue: Set(initialDeckIds))
-        case .edit(let front, let back, let sourceFile, let sourceHeading, let deckIds, let isSuspended):
+        case .edit(let front, let back, let sourceFile, let deckIds, let isSuspended):
             _front = State(initialValue: front)
             _back = State(initialValue: back)
             _sourceFile = State(initialValue: sourceFile ?? "")
-            _sourceHeading = State(initialValue: sourceHeading ?? "")
             _selectedDeckIds = State(initialValue: Set(deckIds))
             _isSuspended = State(initialValue: isSuspended)
         }
@@ -77,7 +75,6 @@ struct CardFormSheet: View {
 
                 Section("Source (Optional)") {
                     TextField("Source File", text: $sourceFile)
-                    TextField("Heading", text: $sourceHeading)
                 }
 
                 if !decks.isEmpty {
@@ -153,7 +150,6 @@ struct CardFormSheet: View {
             front: front.trimmingCharacters(in: .whitespacesAndNewlines),
             back: back.trimmingCharacters(in: .whitespacesAndNewlines),
             sourceFile: sourceFile.isEmpty ? nil : sourceFile,
-            sourceHeading: sourceHeading.isEmpty ? nil : sourceHeading,
             deckId: nil
         )
 
@@ -161,7 +157,7 @@ struct CardFormSheet: View {
             // Preserve deck order matching `decks` so the first selection is stable.
             let ordered = decks.map(\.id).filter { selectedDeckIds.contains($0) }
             try await onSave(request, ordered)
-            if case .edit(_, _, _, _, _, let wasSuspended) = mode, wasSuspended != isSuspended {
+            if case .edit(_, _, _, _, let wasSuspended) = mode, wasSuspended != isSuspended {
                 try await onToggleSuspended?(isSuspended)
             }
             dismiss()

--- a/fasolt.ios/Fasolt/Views/Shared/CardDetailSheet.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/CardDetailSheet.swift
@@ -74,10 +74,6 @@ struct CardDetailSheet: View {
                         HStack(spacing: 4) {
                             Image(systemName: "doc.text")
                             Text(sourceFile)
-                            if let heading = card.sourceHeading {
-                                Text("\u{00B7}")
-                                Text(heading)
-                            }
                         }
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/fasolt.ios/Fasolt/Views/Shared/CardDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/CardDetailView.swift
@@ -113,10 +113,6 @@ struct CardDetailView: View {
                     HStack(spacing: 4) {
                         Image(systemName: "doc.text")
                         Text(sourceFile)
-                        if let heading = card.sourceHeading {
-                            Text("·")
-                            Text(heading)
-                        }
                     }
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -179,7 +175,6 @@ struct CardDetailView: View {
                     front: card.front,
                     back: card.back,
                     sourceFile: card.sourceFile,
-                    sourceHeading: card.sourceHeading,
                     deckIds: currentDeckIds,
                     isSuspended: card.isSuspended
                 ),
@@ -189,7 +184,6 @@ struct CardDetailView: View {
                         front: request.front,
                         back: request.back,
                         sourceFile: request.sourceFile,
-                        sourceHeading: request.sourceHeading,
                         deckIds: deckIds
                     )
                     try await onSaveEdit?(updateRequest)

--- a/fasolt.ios/Fasolt/Views/Shared/CardHelpers.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/CardHelpers.swift
@@ -7,7 +7,6 @@ protocol CardDisplayable {
     var front: String { get }
     var back: String { get }
     var sourceFile: String? { get }
-    var sourceHeading: String? { get }
     var state: String { get }
     var dueAt: String? { get }
     var stability: Double? { get }

--- a/fasolt.ios/Fasolt/Views/Shared/PagedCardDetailView.swift
+++ b/fasolt.ios/Fasolt/Views/Shared/PagedCardDetailView.swift
@@ -124,7 +124,6 @@ struct PagedCardDetailView: View {
                         front: card.front,
                         back: card.back,
                         sourceFile: card.sourceFile,
-                        sourceHeading: card.sourceHeading,
                         deckIds: deckIds,
                         isSuspended: card.isSuspended
                     ),
@@ -134,7 +133,6 @@ struct PagedCardDetailView: View {
                             front: request.front,
                             back: request.back,
                             sourceFile: request.sourceFile,
-                            sourceHeading: request.sourceHeading,
                             deckIds: deckIds
                         )
                         try await onSaveEdit(card.id, updateRequest)

--- a/fasolt.ios/Fasolt/Views/Study/CardView.swift
+++ b/fasolt.ios/Fasolt/Views/Study/CardView.swift
@@ -5,7 +5,6 @@ struct CardView: View {
     let label: String
     let text: String
     let sourceFile: String?
-    let sourceHeading: String?
     var svg: String? = nil
     var cardId: String? = nil
     var questionText: String? = nil
@@ -81,16 +80,7 @@ struct CardView: View {
 
                     // Footer
                     HStack(alignment: .firstTextBaseline) {
-                        if let sourceHeading {
-                            HStack(spacing: 4) {
-                                Image(systemName: "number")
-                                    .font(.system(size: 9))
-                                Text(sourceHeading)
-                                    .font(.system(size: 11, design: .monospaced))
-                            }
-                            .foregroundStyle(FasoltTheme.ink2)
-                            .lineLimit(1)
-                        } else if !showAnswer {
+                        if !showAnswer {
                             Text("tap to reveal")
                                 .font(.system(size: 11))
                                 .foregroundStyle(FasoltTheme.ink2)
@@ -128,8 +118,7 @@ struct CardView: View {
     CardView(
         label: "Question",
         text: "What organelle is responsible for producing ATP?",
-        sourceFile: "biology-101.md",
-        sourceHeading: "Cell Structure"
+        sourceFile: "biology-101.md"
     )
     .padding()
     .background(FasoltTheme.paper0)
@@ -140,7 +129,6 @@ struct CardView: View {
         label: "Question",
         text: "What shape is this?",
         sourceFile: nil,
-        sourceHeading: nil,
         svg: "<svg viewBox=\"0 0 100 100\" xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"50\" cy=\"50\" r=\"40\" fill=\"blue\"/></svg>"
     )
     .padding()

--- a/fasolt.ios/Fasolt/Views/Study/StudyView.swift
+++ b/fasolt.ios/Fasolt/Views/Study/StudyView.swift
@@ -140,7 +140,6 @@ struct StudyView: View {
                     label: viewModel.isFlipped ? "Answer" : "Question",
                     text: viewModel.isFlipped ? card.back : card.front,
                     sourceFile: card.sourceFile,
-                    sourceHeading: viewModel.isFlipped ? card.sourceHeading : nil,
                     svg: viewModel.isFlipped ? card.backSvg : card.frontSvg,
                     cardId: card.id,
                     questionText: viewModel.isFlipped ? card.front : nil,

--- a/fasolt.ios/FasoltTests/StudyViewModelTests.swift
+++ b/fasolt.ios/FasoltTests/StudyViewModelTests.swift
@@ -38,7 +38,6 @@ private func makeCard(_ id: String) -> DueCardDTO {
         front: "Q\(id)",
         back: "A\(id)",
         sourceFile: nil,
-        sourceHeading: nil,
         state: "new",
         frontSvg: nil,
         backSvg: nil


### PR DESCRIPTION
Closes #171.

## Summary

- Drops the `SourceHeading` column on `Cards` via a new EF migration (`RemoveSourceHeading`)
- Removes `SourceHeading` / `sourceHeading` from every DTO, request/response shape, MCP tool description, REST endpoint, dev seed and snapshot data carrier
- Removes the field from frontend types, store, create dialog, card detail edit, review card; from iOS models, views, view-models, repositories; and from Android models, repository, form, and study display
- Existing snapshot JSON blobs still contain `sourceHeading` — `System.Text.Json` defaults to ignoring unknown properties, so legacy snapshots deserialize cleanly and the field is silently dropped on restore

## Why

`sourceHeading` was added when the app parsed markdown headings as anchors into source files. Under the MCP-first model the LLM decides what's a unit of knowledge — `sourceFile` alone is enough provenance, and every client either rendered a half-empty badge or ignored it. Discussion to repurpose it as a generic `comment` field was deferred to a separate issue if/when validated.

## Test plan

- [x] `dotnet test` — 320 passed (Card / Deck / Snapshot / AccountData service tests all updated)
- [x] `npm run build` in `fasolt.client/` — clean
- [x] `npm test` in `fasolt.client/` — 46 passed
- [x] `xcodebuild ... -scheme Fasolt ... build` — `** BUILD SUCCEEDED **`
- [x] `./gradlew assembleDebug` (Android) — `BUILD SUCCESSFUL`
- [x] Playwright smoke against the running stack: card list renders, create-card dialog now shows only Source File (no Heading), card detail edit view shows only Source file (no Section)

## Risks (per issue #171)

- Old MCP clients sending `sourceHeading` get an unknown-parameter error — acceptable, the AI re-reads the tool spec each session.
- Old iOS / Android builds may include `sourceHeading` in JSON request bodies. ASP.NET Core silently ignores unknown fields, so no breakage.
- Data loss is intentional — no production backup taken in this PR; if you want one, snapshot before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)