### PR TITLE
mcp: surface argument errors to LLM clients (#179)

### DIFF
--- a/fasolt.Server/Api/McpTools/McpErrorTranslator.cs
+++ b/fasolt.Server/Api/McpTools/McpErrorTranslator.cs
@@ -1,0 +1,24 @@
+using ModelContextProtocol.Protocol;
+
+namespace Fasolt.Server.Api.McpTools;
+
+public static class McpErrorTranslator
+{
+    public static CallToolResult ToErrorResult(Exception ex, string toolName)
+    {
+        var text = IsInputError(ex)
+            ? $"Invalid arguments for '{toolName}': {ex.Message}"
+            : $"Internal error in '{toolName}' ({ex.GetType().Name}). Check the tool's input schema and retry.";
+
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = text }],
+            IsError = true,
+        };
+    }
+
+    public static bool IsInputError(Exception ex) =>
+        ex is ArgumentException
+        || ex is FormatException
+        || ex is System.Text.Json.JsonException;
+}

--- a/fasolt.Server/Program.cs
+++ b/fasolt.Server/Program.cs
@@ -412,17 +412,34 @@ builder.Services.AddMcpServer(options =>
     .WithToolsFromAssembly()
     .WithRequestFilters(filters =>
     {
-        // Per-tool-call usage signal — sent to ILogger / Seq only, never
-        // to AppLog. Keeps GDPR-sensitive behavioural data out of the admin
-        // DB table (which has no retention policy) and into Seq, where
-        // retention is configurable and the data is queryable by tool name.
         filters.AddCallToolFilter(next => async (context, cancellationToken) =>
         {
             var logger = context.Services?.GetService<ILogger<Program>>();
             var toolName = context.Params?.Name ?? "(unknown)";
             var userId = context.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+            // Per-tool-call usage signal — sent to ILogger / Seq only, never
+            // to AppLog. Keeps GDPR-sensitive behavioural data out of the admin
+            // DB table (which has no retention policy) and into Seq, where
+            // retention is configurable and the data is queryable by tool name.
             logger?.LogInformation("MCP tool {Tool} called by user {UserId}", toolName, userId ?? "(anonymous)");
-            return await next(context, cancellationToken);
+
+            try
+            {
+                return await next(context, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException
+                                       && ex is not ModelContextProtocol.McpException)
+            {
+                // The MCP SDK's default behaviour swallows non-McpException
+                // messages, returning a generic "An error occurred invoking 'X'."
+                // to the LLM. For argument/format/JSON errors the inner message
+                // is exactly what the LLM needs to self-correct its next call.
+                if (Fasolt.Server.Api.McpTools.McpErrorTranslator.IsInputError(ex))
+                    logger?.LogWarning(ex, "MCP tool {Tool} rejected bad arguments for user {UserId}", toolName, userId ?? "(anonymous)");
+                else
+                    logger?.LogError(ex, "MCP tool {Tool} threw for user {UserId}", toolName, userId ?? "(anonymous)");
+                return Fasolt.Server.Api.McpTools.McpErrorTranslator.ToErrorResult(ex, toolName);
+            }
         });
     });
 

--- a/fasolt.Tests/McpErrorTranslatorTests.cs
+++ b/fasolt.Tests/McpErrorTranslatorTests.cs
@@ -1,0 +1,49 @@
+using Fasolt.Server.Api.McpTools;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Fasolt.Tests;
+
+public class McpErrorTranslatorTests
+{
+    [Fact]
+    public void ArgumentException_message_is_surfaced_to_caller()
+    {
+        var ex = new ArgumentException("The arguments dictionary is missing a value for the required parameter 'cards'.");
+
+        var result = McpErrorTranslator.ToErrorResult(ex, "update_cards");
+
+        result.IsError.Should().BeTrue();
+        var text = result.Content.OfType<TextContentBlock>().Single().Text;
+        text.Should().Contain("update_cards");
+        text.Should().Contain("'cards'");
+        text.Should().StartWith("Invalid arguments");
+    }
+
+    [Theory]
+    [InlineData(typeof(ArgumentException))]
+    [InlineData(typeof(ArgumentNullException))]
+    [InlineData(typeof(FormatException))]
+    [InlineData(typeof(System.Text.Json.JsonException))]
+    public void Input_error_types_are_classified_as_user_errors(Type exceptionType)
+    {
+        var ex = (Exception)Activator.CreateInstance(exceptionType, "boom")!;
+        McpErrorTranslator.IsInputError(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Internal_exceptions_get_generic_message_without_leaking_details()
+    {
+        var ex = new InvalidOperationException("connection string foo=bar password=secret");
+
+        var result = McpErrorTranslator.ToErrorResult(ex, "create_cards");
+
+        result.IsError.Should().BeTrue();
+        var text = result.Content.OfType<TextContentBlock>().Single().Text;
+        text.Should().Contain("Internal error");
+        text.Should().Contain("create_cards");
+        text.Should().Contain("InvalidOperationException");
+        text.Should().NotContain("password");
+        text.Should().NotContain("secret");
+    }
+}


### PR DESCRIPTION
## Summary

Extends the existing MCP call-tool filter to catch exceptions and return a structured `CallToolResult { IsError = true }` instead of letting the SDK default swallow the message into a generic `"An error occurred invoking 'X'."`

- **Argument/format/JSON errors** → inner message surfaced verbatim. The LLM gets the real reason (e.g. "missing required parameter 'cards'") and can self-correct.
- **Other exceptions** → generic `"Internal error in 'tool' (TypeName)."` so we don't leak DB connection strings, stack traces, etc. Full details still logged server-side.
- `OperationCanceledException` and `McpException` continue to flow through to the SDK's existing handling.

Translation logic lives in `McpErrorTranslator` with unit tests.

Closes #179.

## Test plan

- [x] `dotnet test` — 327 pass (6 new tests for the translator)
- [ ] Manual MCP smoke: call `update_cards` without `cards` param, verify the response includes "missing … 'cards'" instead of the old generic message
- [ ] Verify a normal successful tool call is unaffected (no regression in the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)