### PR TITLE
mcp(update_cards): slim response to updated count + notFound ids

### DIFF
--- a/fasolt.Server/Api/McpTools/CardTools.cs
+++ b/fasolt.Server/Api/McpTools/CardTools.cs
@@ -102,7 +102,7 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
         return JsonSerializer.Serialize(new { deleted = count > 0, deletedCount = count }, McpJson.Options);
     }
 
-    [McpServerTool, Description("Update one or more existing cards' text or source metadata by cardId. Preserves all review/SRS history.")]
+    [McpServerTool, Description("Update one or more existing cards' text or source metadata by cardId. Preserves all review/SRS history. Returns the number of cards updated and the cardIds of any that were not found (notFound is empty when everything succeeded).")]
     public async Task<string> UpdateCards(
         [Description("Array of card updates. Each needs a cardId and at least one field to update (newFront, newBack, newSourceFile, newFrontSvg, newBackSvg).")] List<BulkUpdateCardItem> cards)
     {
@@ -115,7 +115,7 @@ public class CardTools(CardService cardService, SearchService searchService, IHt
         return JsonSerializer.Serialize(new
         {
             updated = results.Count(r => r.Status == UpdateCardStatus.Success),
-            results
+            notFound = results.Where(r => r.Status == UpdateCardStatus.NotFound).Select(r => r.CardId).ToList(),
         }, McpJson.Options);
     }
 


### PR DESCRIPTION
## Summary

Fixes #181 — the MCP `update_cards` tool returned too much data.

Previously it echoed the full `CardDto` for every updated card, including the `frontSvg`/`backSvg` blobs (hundreds of KB each) and all FSRS scheduling fields, wrapped in a per-card `results` array.

It now returns just:

```json
{ "updated": 3, "notFound": [] }
```

- `updated` — count of cards successfully updated (authoritative write-confirmation).
- `notFound` — cardIds that didn't match; empty when everything succeeded.

### Why this shape

From the consuming agent's perspective, the full card echo is redundant — the caller already holds the cardIds and the values it sent. The only non-reconstructible signal is *which* ids missed, so that's all we surface. The happy path collapses to `{ updated: N, notFound: [] }`.

Considered but rejected: echoing the updated fields back. For text fields the server only `.Trim()`s them, so it'd just repeat the caller's own input. The one real server-side transform is SVG sanitization, and that's already covered by the dedicated `AddSvgToCard` tool which returns the sanitized card.

### Scope

Only the MCP tool boundary in `fasolt.Server/Api/McpTools/CardTools.cs`. The `BulkUpdateCards` service still returns full results (also used by `AddSvgToCard`/`SuspendCard`), so SRS history and existing service-layer tests are untouched. The tool description was updated to document the new return shape.

## Test plan

- [ ] `dotnet build` (no .NET SDK in the dev environment — not yet compiled)
- [ ] `dotnet test` — existing `BulkUpdateCards_*` service tests should remain green (service layer unchanged)
- [ ] Call `update_cards` via MCP with a mix of valid and bogus cardIds; confirm response is `{ updated, notFound }` and that `notFound` lists the bogus ids

https://claude.ai/code/session_011RnXTxMJ6xQrrxUuLEHBbp

---
_Generated by [Claude Code](https://claude.ai/code/session_011RnXTxMJ6xQrrxUuLEHBbp)_