### PR TITLE
Redesign: Things-anchored 'Quiet & Functional' design language

### DIFF
--- a/docs/superpowers/specs/2026-06-13-things-design-language.md
+++ b/docs/superpowers/specs/2026-06-13-things-design-language.md
@@ -1,0 +1,115 @@
+# fasolt design language — "Quiet & Functional" (Things-anchored)
+
+**Date:** 2026-06-13
+**Status:** Approved direction, in implementation
+**Anchor reference:** Cultured Code's *Things* — chosen by the user for being "simple and functional."
+
+## Why this exists
+
+The previous look ("paper & ink, vermilion") was not default-shadcn — it was the *other* generic AI aesthetic: Geist font + warm-neutral paper + one tasteful accent + uppercase-mono micro-labels + 1px hairline grids. That whole vocabulary is the current Vercel/Linear "default good taste" that every polished AI-generated app reaches for, so it still reads as machine-made.
+
+The fix is not a new accent color. It is **committing to restraint with a point of view**, anchored on Things: the things that make Things *not* look AI are all subtractive.
+
+## Principles (the rules every screen obeys)
+
+1. **System font, not a designer font.** UI type is the platform system font (SF on Apple). The only exception is the **fasolt wordmark/logo**, which keeps its Geist logotype. No Geist / Geist Mono / Instrument Serif anywhere in the UI chrome. A system monospace is allowed *only* for genuine code, IDs, and keyboard hints.
+2. **Whitespace over borders and cards.** Prefer air and faint hairline separators to boxed cards and bordered tile-grids. When something must be a surface, make it quiet.
+3. **One accent, used sparingly and meaningfully.** The warm marigold appears only where it carries meaning: the primary action, "today/due" emphasis, active state, and progress. It is not decoration. Per-deck identity dots (blue/green/purple/etc.) are a separate system from the brand accent.
+4. **No gloss.** No gradients, no glow/pulse animation, no inset highlight shadows, no hover-lift transforms, no hard offset shadows. Depth comes from a single very-soft shadow at most, and mostly from hairlines + spacing.
+5. **Sentence case, quiet labels.** Section labels are calm sentence-case grey text (e.g. "Decks"), never wide-tracked uppercase mono.
+6. **Calm motion.** Short, functional transitions (color/opacity ~120ms). Nothing performative.
+7. **Native-portable.** Because this is essentially the iOS design language already, the same tokens, type, and component patterns derive to the iOS app later with minimal translation.
+
+## Color tokens
+
+Defined as CSS variables in `fasolt.client/src/style.css`, consumed everywhere through the existing token names so changes propagate app-wide. Values in OKLCH; hex shown for intuition.
+
+### Light
+| Token | Value (approx hex) | Role |
+|---|---|---|
+| `--paper-0` | `#ffffff` | page background |
+| `--paper-1` | `#ffffff` | surface/card (defined by hairline, not fill) |
+| `--paper-2` | `#f4f4f3` | sunken / hover / input fill / stripe |
+| `--rule-1` | `#ececec` | hairline border/separator |
+| `--rule-2` | `#f2f2f2` | faintest rule |
+| `--ink-0` | `#1c1c1e` | primary text |
+| `--ink-1` | `#6b6b70` | secondary text |
+| `--ink-2` | `#8e8e93` | muted text / quiet labels |
+| `--ink-3` | `#c2c2c7` | tertiary (chevrons, ring tracks) |
+| `--accent` | `#ee9b42` | brand marigold — fills, rings, active, "today" |
+| `--accent-hi` | `#e08f31` | accent hover/pressed |
+| `--accent-text` | `#c9781a` | accent as **text/links on light** (AA-legible) |
+| `--accent-soft` | `#fbeede` | accent tint background |
+| `--accent-on` | `#ffffff` | text/icon on an accent fill |
+
+### Dark (warm charcoal, flat)
+| Token | Value (approx hex) | Role |
+|---|---|---|
+| `--paper-0` | `#1b1b1c` | page background |
+| `--paper-1` | `#242427` | surface/card |
+| `--paper-2` | `#2f2f33` | sunken / hover |
+| `--rule-1` | `#34343a` | hairline |
+| `--rule-2` | `#2c2c30` | faintest rule |
+| `--ink-0` | `#ededf0` | primary text |
+| `--ink-1` | `#a8a8af` | secondary text |
+| `--ink-2` | `#8a8a91` | muted / quiet labels |
+| `--ink-3` | `#5c5c63` | tertiary |
+| `--accent` | `#f2a352` | brand marigold (lifts slightly on dark) |
+| `--accent-hi` | `#f4ad63` | accent hover |
+| `--accent-text` | `#f2a352` | accent as text (legible on dark as-is) |
+| `--accent-soft` | `#3a2c1a` | accent tint background |
+| `--accent-on` | `#ffffff` | text on accent fill |
+
+### Status (review ratings & states)
+Aligned to Apple system hues, kept legible in both themes. "Hard" leans amber/yellow so it reads distinct from the brand marigold when the four rating buttons sit together.
+- `--c-again` red, `--c-hard` amber-yellow, `--c-good` green, `--c-easy` blue.
+- Per-deck identity dots draw from a fixed multi-hue palette (blue `#2e7cf6`/`#0a84ff`, green `#34c759`/`#30d158`, purple `#af52de`/`#bf5af2`, etc.) — unrelated to the brand accent.
+
+## Type
+
+- **Family:** `-apple-system, BlinkMacSystemFont, system-ui, "Segoe UI", Roboto, sans-serif`. Mono: `ui-monospace, "SF Mono", Menlo, monospace` (code/IDs/kbd only).
+- **Wordmark:** keeps `Geist` (logotype only; still loaded for that single use).
+- **Scale (web):** page title ~32px/600 tight; section heading ~16–20px/600; body 14–15px/400; quiet label 12–13px/600 in `--ink-2`; big "hero number" ~54–64px/600 tabular.
+- Tabular lining numerals for all counts/stats.
+- Retire the three-voice system (`fa-serif`, `fa-num-serif`, the Instrument Serif "moments"). Numbers are clean tabular system.
+
+## Component patterns
+
+- **Primary button:** flat `--accent` fill, `--accent-on` text, ~9px radius, weight 600, no shadow/gloss. Hover → `--accent-hi`.
+- **Secondary/ghost button:** transparent or `--paper-1`, hairline border, `--ink-0` text; hover surface is subtle `--paper-2` — **never** the full brand accent.
+- **List row** (decks, cards, sources): a row on the page separated by a faint `--rule-1` hairline (not a boxed card), generous vertical padding (~14–15px), optional leading identity dot or progress ring, name in `--ink-0`, meta in `--ink-2`, due/emphasis in `--accent-text` (light) / `--accent` (dark), trailing `--ink-3` chevron.
+- **Progress ring** (Things-style): ~21px, 3px stroke, `--ink-3`/track + `--accent` arc, round caps, starts at 12 o'clock. Shows due/total per deck.
+- **"Today" marker:** small filled star in `--accent` + sentence-case label.
+- **Quiet section label** (replaces `.fa-cap`): system font, sentence case, 12–13px, weight 600, `--ink-2`, no letter-spacing, no uppercase.
+- **Stat display:** prefer an open row of number+label separated by whitespace over a bordered 4-tile grid. If a container is needed, one quiet surface, hairline, no per-tile borders.
+- **Shadows:** at most `0 1px 3px rgba(0,0,0,.05)` (light). Dark mode leans on surface lightness, not shadow.
+
+## "AI tells" to remove (per-file migration checklist)
+
+For every view / component / page:
+- [ ] No `font-family` literal of `Geist` (except the wordmark), `Geist Mono`, or `Instrument Serif` → system / system-mono.
+- [ ] No hardcoded vermilion or old accent hex/oklch → use `--accent` / `--accent-text`.
+- [ ] No hardcoded status/green/streak oklch literals → use status tokens.
+- [ ] Uppercase wide-tracked mono labels (`.fa-cap` look) → quiet sentence-case labels.
+- [ ] Boxed bordered tile-grids → whitespace + hairlines where it reads cleaner.
+- [ ] Gloss removed: inset-highlight shadows, glow/pulse, hover-lift transforms, gradients, hard offset shadows.
+- [ ] Accent used only for action/active/today/progress — not as decoration or default hover surface.
+- [ ] Both light and dark verified to use tokens (no theme-blind hardcoded colors).
+
+## Scope of rollout
+
+Foundation (frozen before fan-out): `index.html` (fonts), `tailwind.config.js` (font families), `src/style.css` (tokens + shared `.fa-*` classes).
+
+Then every screen and shared piece is swept for the checklist above:
+- Chrome: `AppLayout`, `TopBar`, `BottomNav`, `AppFooter`.
+- App views: Study, Progress, Cards, CardDetail, CardTable, Decks, DeckDetail, DeckSnapshots, RestoreSnapshot, Sources, Review, StudyView's review flow (`ReviewCard`, `RatingButtons`, `SessionComplete`), Settings, Mcp, Algorithm, admin views.
+- Marketing/legal: Landing, Privacy, Terms, Impressum, NotFound.
+- Dialogs & shared: the `CardCreateDialog`/`*Dialog` family, `ProgressMeter`, `KbdHint`, `SearchResults`, `BulkActionBar`, `ToolSwitcher`, `ThemeToggle`.
+- shadcn `ui/` primitives: ensure hover/selected states use subtle surfaces (not brand orange) and inherit the new tokens.
+- Auth (server-rendered): `fasolt.Server/Pages/**/*.cshtml` + `src/auth.css`.
+
+## Verification
+
+- `npm run build` (vue-tsc + vite) passes.
+- Spot-check key screens (Study, Review, Decks, Cards, Landing) in light **and** dark in a browser; confirm no Geist UI text, no vermilion, no uppercase-mono labels, no gloss.
+- iOS derivation is a later, separate effort that reuses these tokens/patterns.

--- a/fasolt.client/index.html
+++ b/fasolt.client/index.html
@@ -8,10 +8,12 @@
       name="description"
       content="fasolt is MCP-first spaced repetition for markdown notes. Let your AI agent turn notes into flashcards, then study them with FSRS on the web or iOS."
     />
-    <meta name="theme-color" content="#0b111a" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1b1b1c" media="(prefers-color-scheme: dark)" />
+    <!-- The UI uses the system font. Geist is loaded for the fasolt wordmark (logotype) only. -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@500;600;700&display=swap" rel="stylesheet" />
     <script>
       // Apply dark class before the SPA mounts so dark-mode users don't see a
       // light-theme flash. Must stay in sync with useDarkMode.ts.

--- a/fasolt.client/src/auth.css
+++ b/fasolt.client/src/auth.css
@@ -21,24 +21,35 @@
 
 @layer base {
   :root {
-    --paper-0: oklch(0.985 0.004 75);
-    --paper-1: oklch(0.970 0.005 75);
-    --paper-2: oklch(0.945 0.006 75);
-    --rule-1:  oklch(0.905 0.006 75);
-    --rule-2:  oklch(0.925 0.005 75);
-    --ink-0:   oklch(0.18  0.012 60);
-    --ink-1:   oklch(0.36  0.011 60);
-    --ink-2:   oklch(0.55  0.008 60);
-    --ink-3:   oklch(0.72  0.005 75);
-    --accent:  oklch(0.61  0.17 40);
-    --accent-hi: oklch(0.55 0.18 38);
-    --accent-soft: oklch(0.945 0.045 55);
-    --accent-on: #ffffff;
-    --c-again: oklch(0.60 0.18 25);
-    --c-hard:  oklch(0.65 0.16 65);
-    --c-good:  oklch(0.55 0.13 155);
-    --c-easy:  oklch(0.55 0.14 245);
-    --radius: 0.5rem;
+    /* paper + ink (light) — white page, hairlines + air do the structuring.
+       Mirrors the light-theme palette in src/style.css. Auth is always light. */
+    --paper-0: #ffffff;
+    --paper-1: #ffffff;
+    --paper-2: #f4f4f3;
+    --rule-1:  #ececec;
+    --rule-2:  #f2f2f2;
+    --ink-0:   #1c1c1e;
+    --ink-1:   #6b6b70;
+    --ink-2:   #8e8e93;
+    --ink-3:   #c2c2c7;
+
+    /* brand marigold accent */
+    --accent:      #ee9b42;
+    --accent-hi:   #e08f31;
+    --accent-text: #c9781a;
+    --accent-soft: #fbeede;
+    --accent-on:   #ffffff;
+
+    /* status hues */
+    --c-again: #ff3b30;
+    --c-hard:  #f5b400;
+    --c-good:  #34c759;
+    --c-easy:  #2e7cf6;
+
+    /* shadows — at most a whisper */
+    --sh-2: 0 1px 3px rgba(0,0,0,.05);
+
+    --radius: 0.625rem;
   }
 
   * {
@@ -47,7 +58,7 @@
 
   body {
     @apply bg-background text-foreground;
-    font-family: 'Geist', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', Roboto, sans-serif;
     font-size: 14px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -89,7 +100,8 @@
     color: var(--ink-0);
   }
   .oauth-card {
-    @apply relative w-full max-w-sm rounded-lg border border-border bg-card p-6 shadow-sm;
+    @apply relative w-full max-w-sm rounded-xl border border-border bg-card p-6;
+    box-shadow: var(--sh-2);
   }
   .oauth-card h1 {
     @apply mb-2 text-center text-base font-semibold text-foreground;
@@ -109,21 +121,33 @@
   .oauth-field input[type=text],
   .oauth-field input[type=email],
   .oauth-field input[type=password] {
-    @apply w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2;
+    @apply w-full rounded-lg border border-input px-3 py-2 text-base transition-colors placeholder:text-muted-foreground focus-visible:outline-none;
+    background: var(--paper-2);
+  }
+  .oauth-field input[type=text]:focus-visible,
+  .oauth-field input[type=email]:focus-visible,
+  .oauth-field input[type=password]:focus-visible {
+    border-color: var(--accent);
+    background: var(--paper-1);
   }
   .oauth-field input[name="Input.Code"],
   .oauth-field input[name=code] {
     @apply py-3 text-center font-mono text-2xl tracking-[0.5em];
   }
   .oauth-btn {
-    @apply mt-1 inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors disabled:pointer-events-none disabled:opacity-50;
+    @apply mt-1 inline-flex h-10 w-full items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold transition-colors disabled:pointer-events-none disabled:opacity-50;
+    background: var(--accent);
+    color: var(--accent-on);
+    border: 1px solid var(--accent);
   }
-  .oauth-btn:hover { background: var(--ink-1); }
+  .oauth-btn:hover { background: var(--accent-hi); border-color: var(--accent-hi); }
+  /* Provider buttons keep the providers' own brand identity (Apple black,
+     GitHub charcoal) — these are third-party brand colors, not fasolt theme. */
   .oauth-btn-apple {
-    @apply mb-2 inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-black px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-black/85;
+    @apply mb-2 inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-black px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-black/85;
   }
   .oauth-btn-github {
-    @apply mb-2 inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-[#24292f] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#32383f];
+    @apply mb-2 inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-[#24292f] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#32383f];
   }
   .oauth-divider {
     @apply my-3 flex items-center gap-3 text-xs text-muted-foreground;
@@ -145,7 +169,8 @@
     @apply mt-4 flex flex-col items-center gap-1 text-center text-xs text-muted-foreground;
   }
   .oauth-footer a {
-    @apply text-accent hover:underline;
+    color: var(--accent-text);
+    @apply hover:underline;
   }
   .oauth-permissions {
     @apply mb-5 rounded-md border border-border bg-muted p-3;
@@ -161,7 +186,7 @@
     @apply text-muted-foreground;
   }
   .oauth-btn-secondary {
-    @apply mt-2 inline-flex h-10 w-full items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted;
+    @apply mt-2 inline-flex h-10 w-full items-center justify-center rounded-lg border border-input bg-card px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted;
   }
   .oauth-rules {
     @apply mt-1 list-none space-y-0.5 pl-0 text-[11px] text-muted-foreground;
@@ -185,7 +210,8 @@
     @apply mt-0.5 w-auto;
   }
   .oauth-tos a {
-    @apply font-medium text-accent;
+    @apply font-medium;
+    color: var(--accent-text);
   }
   .oauth-resend {
     @apply mt-3 text-center text-xs text-muted-foreground;

--- a/fasolt.client/src/components/AddToDeckDialog.vue
+++ b/fasolt.client/src/components/AddToDeckDialog.vue
@@ -77,11 +77,11 @@ async function moveTo(deckId: string) {
           <span class="fa-tag" :style="{ background: deckColor(d.id) }" />
           <div class="move-row-text">
             <div class="move-row-name">{{ d.name }}</div>
-            <div class="fa-mono move-row-sub">
+            <div class="move-row-sub">
               {{ d.cardCount }} card{{ d.cardCount === 1 ? '' : 's' }}<template v-if="d.isSuspended"> · suspended</template>
             </div>
           </div>
-          <span class="move-row-cta fa-mono">add ›</span>
+          <span class="move-row-cta">Add ›</span>
         </button>
 
         <div v-if="filteredDecks.length === 0" class="move-empty">

--- a/fasolt.client/src/components/AppFooter.vue
+++ b/fasolt.client/src/components/AppFooter.vue
@@ -63,11 +63,11 @@ onMounted(async () => {
   color: var(--ink-3);
   transition: color .12s;
 }
-.footer-gh:hover { color: var(--ink-0); }
+.footer-gh:hover { color: var(--accent-text); }
 .footer-link {
   color: var(--ink-2);
   text-decoration: none;
   transition: color .12s;
 }
-.footer-link:hover { color: var(--ink-0); }
+.footer-link:hover { color: var(--accent-text); }
 </style>

--- a/fasolt.client/src/components/BulkActionBar.vue
+++ b/fasolt.client/src/components/BulkActionBar.vue
@@ -29,7 +29,7 @@ defineEmits<{
   >
     <div class="bulk-bar-left">
       <span class="fa-num bulk-count">{{ count }}</span>
-      <span class="bulk-label">selected</span>
+      <span class="fa-cap bulk-label">selected</span>
     </div>
     <div class="bulk-bar-actions">
       <button class="bulk-action" :disabled="busy" @click="$emit('addToDeck')">
@@ -70,10 +70,11 @@ defineEmits<{
   align-items: center;
   gap: 14px;
   padding: 9px 14px;
-  border: 1px solid var(--accent);
-  background: var(--accent-soft);
-  border-radius: 10px;
-  animation: bar-pop .2s cubic-bezier(.4,0,.2,1) both;
+  border: 1px solid var(--rule-1);
+  background: var(--paper-1);
+  border-radius: 12px;
+  box-shadow: var(--sh-2);
+  animation: bar-fade .15s ease both;
   transition: opacity .12s;
 }
 .bulk-bar.is-busy {
@@ -85,29 +86,25 @@ defineEmits<{
   cursor: progress;
   opacity: 0.6;
 }
-@keyframes bar-pop {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
+@keyframes bar-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 .bulk-bar-left {
   display: flex;
   align-items: baseline;
   gap: 6px;
   padding-right: 12px;
-  border-right: 1px solid color-mix(in oklch, var(--accent) 25%, transparent);
+  border-right: 1px solid var(--rule-1);
 }
 .bulk-count {
   font-size: 20px;
   line-height: 1;
-  font-weight: 500;
-  color: var(--accent-hi);
+  font-weight: 600;
+  color: var(--accent-text);
 }
 .bulk-label {
-  font-family: 'Geist Mono', ui-monospace, monospace;
-  text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.18em;
-  color: var(--accent-hi);
+  font-size: 11px;
 }
 .bulk-bar-actions {
   display: flex;
@@ -126,20 +123,18 @@ defineEmits<{
   font-weight: 500;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
-  color: var(--accent-hi);
+  border-radius: 7px;
+  color: var(--ink-0);
   cursor: pointer;
-  transition: background .12s, border-color .12s, color .12s;
+  transition: background .12s, color .12s;
 }
 .bulk-action:hover {
-  background: var(--paper-1);
-  border-color: var(--accent);
+  background: var(--paper-2);
   color: var(--ink-0);
 }
 .bulk-action.is-danger { color: var(--c-again); }
 .bulk-action.is-danger:hover {
-  border-color: var(--c-again);
-  background: color-mix(in oklch, var(--c-again) 8%, var(--paper-1));
+  background: var(--paper-2);
   color: var(--c-again);
 }
 .bulk-clear {
@@ -148,15 +143,15 @@ defineEmits<{
   justify-content: center;
   width: 26px;
   height: 26px;
-  border-radius: 5px;
+  border-radius: 7px;
   background: transparent;
   border: 1px solid transparent;
-  color: var(--accent-hi);
+  color: var(--ink-2);
   cursor: pointer;
-  transition: background .12s, border-color .12s;
+  transition: background .12s, color .12s;
 }
 .bulk-clear:hover {
-  background: var(--paper-1);
-  border-color: var(--accent);
+  background: var(--paper-2);
+  color: var(--ink-0);
 }
 </style>

--- a/fasolt.client/src/components/CardCreateDialog.vue
+++ b/fasolt.client/src/components/CardCreateDialog.vue
@@ -78,48 +78,48 @@ async function save() {
   <Dialog :open="open" @update:open="emit('update:open', $event)">
     <DialogContent class="max-w-2xl max-h-[85vh] overflow-y-auto">
       <DialogHeader>
-        <DialogTitle class="text-sm">{{ cardCount > 1 ? `Create ${cardCount} cards` : 'Create card' }}</DialogTitle>
+        <DialogTitle>{{ cardCount > 1 ? `Create ${cardCount} cards` : 'Create card' }}</DialogTitle>
       </DialogHeader>
 
       <div class="space-y-4">
         <!-- Source metadata -->
-        <div class="space-y-1">
-          <label class="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.1em]">Source file</label>
+        <div class="space-y-1.5">
+          <label class="fa-cap block">Source file</label>
           <input
             v-model="sourceFile"
             type="text"
             placeholder="e.g. distributed-systems.md"
-            class="w-full rounded border border-border bg-transparent px-3 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+            class="fa-field"
           />
         </div>
 
         <!-- Single front -->
-        <div v-if="isSingle" class="space-y-1">
-          <label class="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.1em]">Front (question)</label>
+        <div v-if="isSingle" class="space-y-1.5">
+          <label class="fa-cap block">Front (question)</label>
           <textarea
             v-if="!showPreview"
             v-model="fronts[0]"
-            class="w-full rounded border border-border bg-transparent px-3 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+            class="fa-field"
             rows="2"
           />
-          <div v-else class="prose dark:prose-invert max-w-none rounded border border-border/60 p-3" v-html="render(fronts[0])" />
+          <div v-else class="fa-preview fa-prose" v-html="render(fronts[0])" />
         </div>
 
         <!-- Multiple fronts -->
         <div v-else class="space-y-2">
-          <label class="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.1em]">Fronts (one card per question)</label>
+          <label class="fa-cap block">Fronts (one card per question)</label>
           <div v-for="(front, idx) in fronts" :key="idx" class="flex items-start gap-2">
             <textarea
               v-if="!showPreview"
               v-model="fronts[idx]"
-              class="flex-1 rounded border border-border bg-transparent px-3 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+              class="fa-field flex-1"
               rows="1"
             />
-            <div v-else class="flex-1 prose dark:prose-invert rounded border border-border/60 p-2 text-xs" v-html="render(front)" />
+            <div v-else class="fa-preview fa-prose flex-1" v-html="render(front)" />
             <Button
               variant="ghost"
               size="sm"
-              class="h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
+              class="h-7 w-7 p-0 text-ink-2 hover:text-destructive shrink-0"
               @click="removeFront(idx)"
             >
               &times;
@@ -128,33 +128,74 @@ async function save() {
         </div>
 
         <!-- Back -->
-        <div class="space-y-1">
-          <label class="text-[10px] font-medium text-muted-foreground uppercase tracking-[0.1em]">Back (answer) {{ !isSingle ? '— shared by all cards' : '' }}</label>
+        <div class="space-y-1.5">
+          <label class="fa-cap block">Back (answer) {{ !isSingle ? '— shared by all cards' : '' }}</label>
           <textarea
             v-if="!showPreview"
             v-model="back"
-            class="w-full rounded border border-border bg-transparent px-3 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+            class="fa-field"
             rows="8"
           />
-          <div v-else class="prose dark:prose-invert max-w-none rounded border border-border/60 p-3" v-html="renderedBack" />
+          <div v-else class="fa-preview fa-prose" v-html="renderedBack" />
         </div>
 
-        <div v-if="isLong" class="rounded border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning">
+        <div v-if="isLong" class="fa-note">
           This card is quite long ({{ back.length.toLocaleString() }} chars). Consider creating cards from specific sections instead.
         </div>
 
-        <div v-if="error" class="text-xs text-destructive">{{ error }}</div>
+        <div v-if="error" class="fa-error">{{ error }}</div>
       </div>
 
       <DialogFooter class="gap-2">
-        <Button variant="outline" size="sm" class="text-xs" @click="showPreview = !showPreview">
+        <button class="fa-btn fa-btn-ghost" @click="showPreview = !showPreview">
           {{ showPreview ? 'Edit' : 'Preview' }}
-        </Button>
-        <Button variant="outline" size="sm" class="text-xs" @click="emit('update:open', false)">Cancel</Button>
-        <Button size="sm" class="text-xs" :disabled="saving" @click="save">
-          {{ saving ? 'Saving...' : cardCount > 1 ? `Create ${cardCount} cards` : 'Create card' }}
-        </Button>
+        </button>
+        <button class="fa-btn" @click="emit('update:open', false)">Cancel</button>
+        <button class="fa-btn fa-btn-primary" :disabled="saving" @click="save">
+          {{ saving ? 'Saving…' : cardCount > 1 ? `Create ${cardCount} cards` : 'Create card' }}
+        </button>
       </DialogFooter>
     </DialogContent>
   </Dialog>
 </template>
+
+<style scoped>
+/* Text inputs / textareas — flat, hairline, accent ring on focus */
+.fa-field {
+  width: 100%;
+  border-radius: 9px;
+  border: 1px solid var(--rule-1);
+  background: var(--paper-1);
+  padding: 8px 11px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--ink-0);
+  transition: border-color .12s;
+}
+.fa-field::placeholder { color: var(--ink-3); }
+.fa-field:focus { outline: none; border-color: var(--accent); }
+textarea.fa-field { resize: vertical; }
+
+/* Rendered markdown preview surface */
+.fa-preview {
+  border: 1px solid var(--rule-1);
+  border-radius: 9px;
+  padding: 10px 12px;
+  background: var(--paper-2);
+}
+
+/* Soft advisory note (long-card warning) — quiet, no glow */
+.fa-note {
+  border: 1px solid var(--rule-1);
+  border-radius: 9px;
+  padding: 8px 11px;
+  font-size: 12px;
+  color: var(--ink-1);
+  background: var(--paper-2);
+}
+
+.fa-error {
+  font-size: 12.5px;
+  color: var(--c-again);
+}
+</style>

--- a/fasolt.client/src/components/CardDeleteDialog.vue
+++ b/fasolt.client/src/components/CardDeleteDialog.vue
@@ -46,7 +46,7 @@ async function confirmDelete() {
           </template>
         </DialogDescription>
       </DialogHeader>
-      <div v-if="error" class="text-xs text-destructive">{{ error }}</div>
+      <div v-if="error" class="fa-error">{{ error }}</div>
       <DialogFooter>
         <Button variant="outline" @click="emit('update:open', false)">Cancel</Button>
         <Button variant="destructive" @click="confirmDelete">Delete</Button>
@@ -54,3 +54,10 @@ async function confirmDelete() {
     </DialogContent>
   </Dialog>
 </template>
+
+<style scoped>
+.fa-error {
+  font-size: 12.5px;
+  color: var(--c-again);
+}
+</style>

--- a/fasolt.client/src/components/CardTable.vue
+++ b/fasolt.client/src/components/CardTable.vue
@@ -336,10 +336,11 @@ const table = useVueTable({
   background: var(--paper-2);
 }
 .card-table-head {
-  font-family: 'Geist Mono', ui-monospace, monospace;
-  text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.18em;
+  font-family: inherit;
+  text-transform: none;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0;
   color: var(--ink-2);
   padding: 10px 14px;
   height: 36px;
@@ -352,7 +353,7 @@ const table = useVueTable({
   align-items: center;
   gap: 5px;
 }
-.sort-icon { color: var(--accent); font-family: 'Geist Mono', monospace; }
+.sort-icon { color: var(--accent); font-family: ui-monospace, 'SF Mono', Menlo, monospace; }
 
 :deep(.card-table-row) {
   border-bottom: 1px solid var(--rule-2);
@@ -437,7 +438,7 @@ const table = useVueTable({
 :deep(.state-chip) {
   display: inline-block;
   font-size: 10.5px;
-  font-family: 'Geist Mono', ui-monospace, monospace;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
   padding: 2px 7px;
   border: 1px solid currentColor;
   border-radius: 3px;
@@ -537,7 +538,14 @@ const table = useVueTable({
 }
 :deep(.sel-box.is-indeterminate::after) {
   display: block;
-  background: no-repeat center/10px 2px linear-gradient(white, white);
+  inset: auto;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 2px;
+  transform: translate(-50%, -50%);
+  background: var(--accent-on);
 }
 :deep(.card-table-row:hover .sel-box:not(.is-checked):not(.is-indeterminate)) {
   border-color: var(--ink-3);

--- a/fasolt.client/src/components/DeleteAccountDialog.vue
+++ b/fasolt.client/src/components/DeleteAccountDialog.vue
@@ -50,13 +50,24 @@ async function confirmDelete() {
           This action is permanent and cannot be undone. All your cards, decks, and study progress will be deleted.
         </DialogDescription>
       </DialogHeader>
-      <div v-if="error" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">{{ error }}</div>
+      <div v-if="error" class="fa-error-box">{{ error }}</div>
       <DialogFooter>
         <Button variant="outline" @click="emit('update:open', false)">Cancel</Button>
         <Button variant="destructive" :disabled="deleting" @click="confirmDelete">
-          {{ deleting ? 'Deleting...' : 'Delete my account' }}
+          {{ deleting ? 'Deleting…' : 'Delete my account' }}
         </Button>
       </DialogFooter>
     </DialogContent>
   </Dialog>
 </template>
+
+<style scoped>
+.fa-error-box {
+  border: 1px solid var(--rule-1);
+  border-radius: 9px;
+  padding: 8px 11px;
+  font-size: 12.5px;
+  color: var(--c-again);
+  background: var(--paper-2);
+}
+</style>

--- a/fasolt.client/src/components/FasoltStudyPreview.vue
+++ b/fasolt.client/src/components/FasoltStudyPreview.vue
@@ -67,87 +67,74 @@ function startCycle() {
   }, 5300))
 }
 
+const ratings = [
+  { label: 'Again', color: 'var(--c-again)', tint: 'color-mix(in srgb, var(--c-again) 12%, transparent)' },
+  { label: 'Hard', color: 'var(--c-hard)', tint: 'color-mix(in srgb, var(--c-hard) 14%, transparent)' },
+  { label: 'Good', color: 'var(--c-good)', tint: 'color-mix(in srgb, var(--c-good) 12%, transparent)' },
+  { label: 'Easy', color: 'var(--c-easy)', tint: 'color-mix(in srgb, var(--c-easy) 12%, transparent)' },
+]
+
 onMounted(startCycle)
 onBeforeUnmount(clearTimers)
 </script>
 
 <template>
-  <div class="flex flex-col overflow-hidden rounded-xl border border-border/60 bg-card/60 shadow-2xl glow-accent-lg lg:h-[420px]">
+  <div class="preview">
     <!-- Window chrome -->
-    <div class="flex items-center gap-2 px-4 py-3 border-b border-border/60 bg-card/80">
-      <span class="h-2.5 w-2.5 rounded-full bg-[#ff5f57]/80"></span>
-      <span class="h-2.5 w-2.5 rounded-full bg-[#febc2e]/80"></span>
-      <span class="h-2.5 w-2.5 rounded-full bg-[#28c840]/80"></span>
-      <span class="ml-3 text-[11px] text-muted-foreground/70">fasolt — Study</span>
+    <div class="chrome">
+      <span class="dot"></span>
+      <span class="dot"></span>
+      <span class="dot"></span>
+      <span class="chrome-title">fasolt — Study</span>
     </div>
 
     <!-- Body -->
-    <div class="flex-1 px-4 py-4 sm:px-5 sm:py-5">
-      <!-- Context bar -->
-      <div class="mb-3 flex items-center justify-between text-[10px] text-muted-foreground">
-        <div class="flex items-center gap-2">
-          <span class="text-accent uppercase tracking-[0.15em]">Review</span>
-          <span class="text-border">|</span>
-          <span>{{ currentIndex + 1 }} of {{ totalInDeck }}</span>
+    <div class="body">
+      <!-- Today / progress header -->
+      <div class="head">
+        <div class="deck-label">
+          <span class="deck-dot"></span>
+          LLM Basics
         </div>
-        <span class="hidden sm:flex items-center gap-1">
-          <span class="rounded border border-border/60 px-1.5 py-0.5 text-[9px] font-mono">space</span>
-          flip
-        </span>
+        <span class="counter fa-num">{{ currentIndex + 1 }} of {{ totalInDeck }}</span>
       </div>
 
       <!-- Progress meter -->
-      <div class="mb-5 h-1 w-full overflow-hidden rounded bg-border/60">
-        <div class="h-full bg-accent transition-all duration-500" :style="{ width: progressPct + '%' }"></div>
+      <div class="meter">
+        <div class="meter-fill" :style="{ width: progressPct + '%' }"></div>
       </div>
 
       <!-- Card -->
-      <div
-        class="relative rounded border border-border/60 bg-background/60 p-5 transition-all duration-300"
-        :class="isExiting ? 'opacity-0 -translate-y-1' : 'opacity-100 translate-y-0'"
-        style="min-height: 140px;"
-      >
-        <div class="text-[10px] uppercase tracking-[0.2em] mb-3 text-accent/70">
-          {{ isFlipped ? 'Answer' : 'Question' }}
-        </div>
-        <div
-          class="text-[13.5px] leading-relaxed transition-colors duration-300"
-          :class="isFlipped ? 'text-muted-foreground' : 'text-foreground'"
-        >
+      <div class="card" :class="{ 'is-exiting': isExiting }">
+        <div class="card-label">{{ isFlipped ? 'Answer' : 'Question' }}</div>
+        <div class="card-front" :class="{ 'is-muted': isFlipped }">
           {{ card.front }}
         </div>
-        <div
-          v-if="isFlipped"
-          class="mt-3 text-[13.5px] leading-relaxed text-foreground"
-          style="animation: fade-in 350ms ease-out;"
-        >
+        <div v-if="isFlipped" class="card-back">
           {{ card.back }}
         </div>
       </div>
 
       <!-- Below card -->
-      <div class="mt-4 transition-opacity duration-300" :class="isExiting ? 'opacity-0' : 'opacity-100'">
-        <div v-if="!showRating" class="text-center text-[11px] text-muted-foreground">
-          Click the card or press
-          <span class="rounded border border-border/60 px-1.5 py-0.5 text-[9px] font-mono">space</span>
-          to reveal the answer
+      <div class="actions" :class="{ 'is-exiting': isExiting }">
+        <div v-if="!showRating" class="hint">
+          Click the card or press <kbd class="fa-kbd">space</kbd> to reveal the answer
         </div>
-        <div v-else class="flex flex-wrap justify-center gap-2" style="animation: fade-in 250ms ease-out;">
+        <div v-else class="rating-row">
           <button
-            v-for="(r, i) in [
-              { label: 'Again', cls: 'border-destructive/50 text-destructive', activeCls: 'bg-destructive/10' },
-              { label: 'Hard', cls: 'border-warning/50 text-warning', activeCls: 'bg-warning/10' },
-              { label: 'Good', cls: 'border-success/50 text-success', activeCls: 'bg-success/10' },
-              { label: 'Easy', cls: 'border-accent/50 text-accent', activeCls: 'bg-accent/10' },
-            ]"
+            v-for="(r, i) in ratings"
             :key="r.label"
-            class="flex-1 min-w-[70px] rounded border px-3 py-2 text-[11px] font-medium transition-all"
-            :class="[r.cls, highlightedRating === i ? r.activeCls : 'bg-transparent']"
+            class="rating-btn"
+            :class="{ 'is-active': highlightedRating === i }"
+            :style="{
+              '--rb-color': r.color,
+              '--rb-tint': r.tint,
+            }"
             type="button"
             tabindex="-1"
           >
             {{ r.label }}
-            <span class="ml-1 text-[9px] opacity-50">{{ i + 1 }}</span>
+            <span class="rating-key fa-num">{{ i + 1 }}</span>
           </button>
         </div>
       </div>
@@ -156,6 +143,169 @@ onBeforeUnmount(clearTimers)
 </template>
 
 <style scoped>
+.preview {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 14px;
+  border: 1px solid var(--rule-1);
+  background: var(--paper-1);
+  box-shadow: var(--sh-2);
+}
+@media (min-width: 1024px) {
+  .preview { height: 420px; }
+}
+
+/* Window chrome */
+.chrome {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 16px;
+  border-bottom: 1px solid var(--rule-1);
+  background: var(--paper-1);
+}
+.dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--ink-3);
+}
+.chrome-title {
+  margin-left: 8px;
+  font-size: 11px;
+  color: var(--ink-2);
+}
+
+/* Body */
+.body {
+  flex: 1;
+  padding: 18px 18px 20px;
+}
+@media (min-width: 640px) {
+  .body { padding: 20px; }
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.deck-label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--ink-1);
+  font-size: 13px;
+  font-weight: 600;
+}
+.deck-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #2e7cf6;
+}
+.counter {
+  font-size: 12px;
+  color: var(--ink-2);
+}
+
+/* Progress meter */
+.meter {
+  height: 4px;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--paper-2);
+  margin-bottom: 20px;
+}
+.meter-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 999px;
+  transition: width .5s ease;
+}
+
+/* Card */
+.card {
+  position: relative;
+  border-radius: 12px;
+  border: 1px solid var(--rule-1);
+  background: var(--paper-1);
+  padding: 18px;
+  min-height: 140px;
+  transition: opacity .3s, transform .3s;
+}
+.card.is-exiting {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+.card-label {
+  margin-bottom: 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink-2);
+}
+.card-front {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink-0);
+  transition: color .3s;
+}
+.card-front.is-muted { color: var(--ink-2); }
+.card-back {
+  margin-top: 12px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink-0);
+  animation: fade-in 350ms ease-out;
+}
+
+/* Below card */
+.actions {
+  margin-top: 16px;
+  transition: opacity .3s;
+}
+.actions.is-exiting { opacity: 0; }
+.hint {
+  text-align: center;
+  font-size: 12px;
+  color: var(--ink-2);
+}
+.rating-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  animation: fade-in 250ms ease-out;
+}
+.rating-btn {
+  flex: 1;
+  min-width: 70px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border-radius: 9px;
+  border: 1px solid var(--rule-1);
+  background: var(--paper-1);
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink-1);
+  transition: background .12s, border-color .12s, color .12s;
+}
+.rating-btn.is-active {
+  border-color: var(--rb-color);
+  background: var(--rb-tint);
+  color: var(--ink-0);
+}
+.rating-key {
+  font-size: 10px;
+  color: var(--ink-3);
+}
+
 @keyframes fade-in {
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }

--- a/fasolt.client/src/components/ProgressMeter.vue
+++ b/fasolt.client/src/components/ProgressMeter.vue
@@ -53,7 +53,7 @@ const useDots = computed(() => props.total >= 5 && props.total <= 60)
   transition: background .2s;
 }
 .progress-tick.is-done { background: var(--accent); }
-.progress-tick.is-next { background: var(--ink-3); opacity: .7; }
+.progress-tick.is-next { background: var(--ink-3); }
 .progress-bar-track {
   flex: 1;
   height: 3px;

--- a/fasolt.client/src/components/RatingButtons.vue
+++ b/fasolt.client/src/components/RatingButtons.vue
@@ -44,19 +44,16 @@ const ratings: { key: string; label: string; rating: ReviewRating; cssColor: str
   padding: 14px 16px;
   background: var(--paper-1);
   border: 1px solid var(--rule-1);
-  border-bottom: 3px solid var(--rcolor);
-  border-radius: 8px;
+  border-radius: 9px;
   cursor: pointer;
   font: inherit;
   color: inherit;
-  transition: background .12s, border-color .12s, transform .08s;
+  transition: background .12s, border-color .12s;
 }
 .rating-btn:hover {
   background: var(--paper-2);
   border-color: var(--rcolor);
-  border-bottom-color: var(--rcolor);
 }
-.rating-btn:active { transform: translateY(1px); }
 .rating-top {
   display: flex;
   align-items: center;
@@ -69,7 +66,7 @@ const ratings: { key: string; label: string; rating: ReviewRating; cssColor: str
   min-width: 22px;
   height: 22px;
   padding: 0 6px;
-  font-family: 'Geist Mono', monospace;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
   font-size: 11px;
   font-weight: 600;
   color: var(--rcolor);

--- a/fasolt.client/src/components/RemoveFromDeckDialog.vue
+++ b/fasolt.client/src/components/RemoveFromDeckDialog.vue
@@ -81,11 +81,11 @@ async function removeFrom(deckId: string, cardIds: string[]) {
           <span class="fa-tag" :style="{ background: deckColor(row.id) }" />
           <div class="remove-row-text">
             <div class="remove-row-name">{{ row.name }}</div>
-            <div class="fa-mono remove-row-sub">
+            <div class="remove-row-sub">
               {{ row.selectedCount }} of selection {{ row.selectedCount === 1 ? 'is' : 'are' }} in this deck
             </div>
           </div>
-          <span class="remove-row-cta fa-mono">remove ›</span>
+          <span class="remove-row-cta">Remove ›</span>
         </button>
 
         <div v-if="deckRows.length === 0" class="remove-empty">

--- a/fasolt.client/src/components/ReviewCard.vue
+++ b/fasolt.client/src/components/ReviewCard.vue
@@ -111,7 +111,7 @@ function openEdit(cardId: string) {
   align-items: flex-start;
   gap: 12px;
 }
-.card-label { color: var(--accent); }
+.card-label { color: var(--ink-2); }
 
 .card-body {
   flex: 1;
@@ -125,9 +125,10 @@ function openEdit(cardId: string) {
   gap: 20px;
 }
 .card-question {
-  font-family: 'Instrument Serif', serif;
-  font-size: 44px;
-  line-height: 1.1;
+  font-family: inherit;
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 1.15;
   letter-spacing: -0.02em;
   text-align: center;
   max-width: 640px;
@@ -135,8 +136,8 @@ function openEdit(cardId: string) {
 }
 .card-question :deep(p) { margin: 0; }
 .card-question :deep(code) {
-  font-family: 'Geist Mono', monospace;
-  font-size: 0.65em;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 0.8em;
   vertical-align: baseline;
   padding: 0 6px;
   background: var(--paper-2);
@@ -169,7 +170,7 @@ function openEdit(cardId: string) {
 .card-prose :deep(p) { margin: 0 0 0.6em; line-height: 1.6; font-size: 15px; }
 .card-prose :deep(strong) { color: var(--ink-0); font-weight: 600; }
 .card-prose :deep(code) {
-  font-family: 'Geist Mono', monospace;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
   font-size: 0.92em;
   padding: 1px 5px;
   background: var(--paper-2);
@@ -184,7 +185,7 @@ function openEdit(cardId: string) {
   border: 1px solid var(--rule-1);
   border-radius: 6px;
   overflow-x: auto;
-  font-family: 'Geist Mono', monospace;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
   font-size: 13px;
 }
 .card-prose :deep(pre code) { background: transparent; border: none; padding: 0; }
@@ -242,7 +243,7 @@ function openEdit(cardId: string) {
   flex-shrink: 0;
 }
 .card-id:hover { color: var(--ink-1); }
-.card-state { font-size: 9px; }
+.card-state { font-size: 11px; color: var(--ink-2); }
 .card-edit {
   display: inline-flex;
   align-items: center;

--- a/fasolt.client/src/components/SearchResults.vue
+++ b/fasolt.client/src/components/SearchResults.vue
@@ -42,38 +42,36 @@ function globalIndex(flatItems: SearchItem[], type: string, localIndex: number):
 </script>
 
 <template>
-  <div
-    class="absolute left-1/2 -translate-x-1/2 top-full mt-1 z-50 w-[500px] max-h-[70vh] overflow-y-auto rounded border border-border/60 bg-popover shadow-lg"
-  >
-    <div v-if="isLoading" class="px-3 py-6 text-center text-[11px] text-muted-foreground">
-      Searching...
+  <div class="sr-panel">
+    <div v-if="isLoading" class="sr-status">
+      Searching…
     </div>
 
-    <div v-else-if="error" class="px-3 py-6 text-center text-[11px] text-destructive">
+    <div v-else-if="error" class="sr-status sr-status-error">
       {{ error }}
     </div>
 
-    <div v-else-if="!hasResults" class="px-3 py-6 text-center text-[11px] text-muted-foreground">
+    <div v-else-if="!hasResults" class="sr-status">
       No results found
     </div>
 
     <div v-else>
       <!-- Decks -->
       <div v-if="results.decks.length > 0">
-        <div class="px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground">
+        <div class="sr-group-label fa-cap">
           Decks ({{ results.decks.length }})
         </div>
         <button
           v-for="(deck, i) in results.decks"
           :key="deck.id"
-          class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs"
-          :class="activeIndex === globalIndex(flatItems, 'deck', i) ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/10'"
+          class="sr-row"
+          :class="{ 'is-active': activeIndex === globalIndex(flatItems, 'deck', i) }"
           @click="emit('select', { type: 'deck', data: deck })"
           @mouseenter="emit('update:activeIndex', globalIndex(flatItems, 'deck', i))"
         >
-          <span class="shrink-0 text-[10px] text-accent/50">#</span>
-          <span class="truncate"><template v-for="(part, pi) in highlightParts(deck.headline)" :key="pi"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></span>
-          <span class="ml-auto shrink-0 text-[10px] text-muted-foreground">
+          <span class="sr-marker">#</span>
+          <span class="sr-text"><template v-for="(part, pi) in highlightParts(deck.headline)" :key="pi"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></span>
+          <span class="sr-meta">
             {{ deck.cardCount }} cards
           </span>
         </button>
@@ -81,28 +79,27 @@ function globalIndex(flatItems: SearchItem[], type: string, localIndex: number):
 
       <!-- Cards -->
       <div v-if="results.cards.length > 0">
-        <div class="px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.15em] text-muted-foreground"
-             :class="{ 'border-t border-border': results.decks.length > 0 }">
+        <div class="sr-group-label fa-cap" :class="{ 'sr-group-label-divided': results.decks.length > 0 }">
           Cards ({{ results.cards.length }})
         </div>
         <button
           v-for="(card, i) in results.cards"
           :key="card.id"
-          class="flex w-full items-center gap-2 px-3 py-2 text-left text-xs"
-          :class="activeIndex === globalIndex(flatItems, 'card', i) ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/10'"
+          class="sr-row"
+          :class="{ 'is-active': activeIndex === globalIndex(flatItems, 'card', i) }"
           @click="emit('select', { type: 'card', data: card })"
           @mouseenter="emit('update:activeIndex', globalIndex(flatItems, 'card', i))"
         >
-          <span class="shrink-0 text-[10px] text-accent/50">></span>
-          <span class="truncate"><template v-for="(part, pi) in highlightParts(card.headline)" :key="pi"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></span>
-          <span class="ml-auto shrink-0 rounded border border-border bg-secondary px-1.5 py-0.5 text-[10px] text-muted-foreground">
+          <span class="sr-marker">›</span>
+          <span class="sr-text"><template v-for="(part, pi) in highlightParts(card.headline)" :key="pi"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></span>
+          <span class="sr-state">
             {{ card.state }}
           </span>
         </button>
       </div>
 
       <!-- Footer -->
-      <div class="flex gap-3 border-t border-border px-3 py-1.5 text-[10px] text-muted-foreground">
+      <div class="sr-footer">
         <span>↑↓ navigate</span>
         <span>↵ open</span>
         <span>esc close</span>
@@ -110,3 +107,110 @@ function globalIndex(flatItems: SearchItem[], type: string, localIndex: number):
     </div>
   </div>
 </template>
+
+<style scoped>
+.sr-panel {
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  transform: translateX(-50%);
+  margin-top: 6px;
+  z-index: 50;
+  width: 500px;
+  max-height: 70vh;
+  overflow-y: auto;
+  border: 1px solid var(--rule-1);
+  border-radius: 12px;
+  background: var(--paper-1);
+  box-shadow: var(--sh-2);
+}
+
+.sr-status {
+  padding: 24px 12px;
+  text-align: center;
+  font-size: 12.5px;
+  color: var(--ink-2);
+}
+.sr-status-error { color: var(--c-again); }
+
+.sr-group-label {
+  padding: 8px 12px 5px;
+}
+.sr-group-label-divided {
+  border-top: 1px solid var(--rule-1);
+  margin-top: 2px;
+}
+
+.sr-row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 12px;
+  text-align: left;
+  font-size: 13px;
+  color: var(--ink-0);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  transition: background .12s, color .12s;
+}
+.sr-row:hover { background: var(--paper-2); }
+.sr-row.is-active {
+  background: var(--accent);
+  color: var(--accent-on);
+}
+
+.sr-marker {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--ink-3);
+}
+.sr-row.is-active .sr-marker { color: var(--accent-on); }
+
+.sr-text {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.sr-meta {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--ink-2);
+}
+.sr-row.is-active .sr-meta { color: var(--accent-on); opacity: .82; }
+
+.sr-state {
+  margin-left: auto;
+  flex-shrink: 0;
+  padding: 1px 7px;
+  font-size: 10.5px;
+  color: var(--ink-1);
+  background: var(--paper-2);
+  border: 1px solid var(--rule-1);
+  border-radius: 999px;
+}
+.sr-row.is-active .sr-state {
+  color: var(--accent-on);
+  background: transparent;
+  border-color: rgba(255, 255, 255, .35);
+}
+
+/* Highlighted match: keep readable when the row is the active accent fill */
+.sr-row.is-active mark {
+  background: rgba(255, 255, 255, .25);
+  color: var(--accent-on);
+}
+
+.sr-footer {
+  display: flex;
+  gap: 12px;
+  padding: 7px 12px;
+  border-top: 1px solid var(--rule-1);
+  font-size: 11px;
+  color: var(--ink-2);
+}
+</style>

--- a/fasolt.client/src/components/SessionComplete.vue
+++ b/fasolt.client/src/components/SessionComplete.vue
@@ -79,14 +79,15 @@ const total = computed(() => breakdown.value.reduce((a, b) => a + b.n, 0) || 1)
 .hero { display: flex; flex-direction: column; }
 .accent-label { color: var(--accent); }
 .hero-title {
-  font-family: 'Instrument Serif', serif;
-  font-size: 72px;
-  line-height: 1;
+  font-family: inherit;
+  font-size: 56px;
+  font-weight: 600;
+  line-height: 1.02;
   letter-spacing: -0.03em;
   margin: 12px 0 0;
   color: var(--ink-0);
 }
-@media (max-width: 600px) { .hero-title { font-size: 52px; } }
+@media (max-width: 600px) { .hero-title { font-size: 44px; } }
 .hero-sub {
   margin-top: 14px;
   font-size: 16px;

--- a/fasolt.client/src/components/TerminalDemo.vue
+++ b/fasolt.client/src/components/TerminalDemo.vue
@@ -24,46 +24,48 @@ const lines: TerminalLine[] = [
 </script>
 
 <template>
+  <!-- Terminal mock keeps a dark + mono treatment by design, but de-glossed:
+       no glow, no gradient, at most a whisper-soft shadow, system monospace. -->
   <div
-    class="overflow-hidden rounded border border-border/60 shadow-2xl glow-accent-lg"
-    style="background: #0a0e17"
+    class="fa-mono overflow-hidden rounded-xl border"
+    style="background: #16181d; border-color: #2a2d35; box-shadow: var(--sh-2)"
   >
     <!-- Window chrome -->
-    <div class="flex items-center gap-2 px-4 py-3 border-b border-white/5" style="background: #0f1420">
-      <span class="h-2.5 w-2.5 rounded-full bg-[#ff5f57]/80"></span>
-      <span class="h-2.5 w-2.5 rounded-full bg-[#febc2e]/80"></span>
-      <span class="h-2.5 w-2.5 rounded-full bg-[#28c840]/80"></span>
-      <span class="ml-3 text-[11px] text-white/20">terminal</span>
+    <div class="flex items-center gap-2 px-4 py-3 border-b" style="background: #1c1f26; border-color: #2a2d35">
+      <span class="h-2.5 w-2.5 rounded-full" style="background: var(--c-again)"></span>
+      <span class="h-2.5 w-2.5 rounded-full" style="background: var(--c-hard)"></span>
+      <span class="h-2.5 w-2.5 rounded-full" style="background: var(--c-good)"></span>
+      <span class="ml-3 text-[11px]" style="color: #6b7280">terminal</span>
     </div>
 
     <!-- Terminal body -->
-    <div class="px-5 py-4 text-[12.5px] leading-relaxed" style="color: #d1d5db">
+    <div class="px-5 py-4 text-[12.5px] leading-relaxed" style="color: #c5c8cf">
       <template v-for="(line, i) in lines" :key="i">
         <div v-if="line.type === 'blank'" class="h-3"></div>
         <div v-else-if="line.type === 'prompt'" class="flex gap-2 mb-1">
-          <span class="text-[hsl(188,86%,53%)]">›</span>
-          <span class="text-white/90">{{ line.text }}</span>
+          <span style="color: var(--accent)">›</span>
+          <span style="color: #e8eaee">{{ line.text }}</span>
         </div>
         <div v-else-if="line.type === 'success'" class="flex gap-2">
-          <span class="text-emerald-400/90">{{ line.text }}</span>
+          <span style="color: var(--c-good)">{{ line.text }}</span>
         </div>
         <div v-else-if="line.type === 'dim'" class="flex gap-2">
-          <span class="text-white/30">{{ line.text }}</span>
+          <span style="color: #6b7280">{{ line.text }}</span>
         </div>
         <div v-else-if="line.type === 'output-link'" class="flex gap-1">
-          <span class="text-white/60">{{ line.text.split('https://')[0] }}</span><span class="text-[hsl(188,86%,53%)] underline decoration-[hsl(188,86%,53%)]/30 underline-offset-2">https://{{ line.text.split('https://')[1] }}</span>
+          <span style="color: #9ca3af">{{ line.text.split('https://')[0] }}</span><span class="underline underline-offset-2" style="color: var(--accent)">https://{{ line.text.split('https://')[1] }}</span>
         </div>
         <div v-else-if="line.type === 'output'" class="flex gap-2">
-          <span class="text-white/60">{{ line.text }}</span>
+          <span style="color: #9ca3af">{{ line.text }}</span>
         </div>
       </template>
 
-      <!-- Cursor -->
+      <!-- Cursor — static block, no glow/pulse -->
       <div class="flex gap-2 mt-1">
-        <span class="text-[hsl(188,86%,53%)]">›</span>
+        <span style="color: var(--accent)">›</span>
         <span
-          class="inline-block w-[7px] h-[14px] align-text-bottom animate-glow-pulse rounded-sm"
-          style="background: hsl(188, 86%, 53%)"
+          class="inline-block w-[7px] h-[14px] align-text-bottom rounded-sm"
+          style="background: var(--accent)"
         ></span>
       </div>
     </div>

--- a/fasolt.client/src/components/ThemeToggle.vue
+++ b/fasolt.client/src/components/ThemeToggle.vue
@@ -56,8 +56,7 @@ const labels = { light: 'Light', dark: 'Dark', auto: 'Auto' } as const
   transition: background .12s, border-color .12s, color .12s;
 }
 .theme-btn:hover {
-  background: var(--paper-1);
-  border-color: var(--rule-1);
+  background: var(--paper-2);
   color: var(--ink-0);
 }
 .theme-item {

--- a/fasolt.client/src/components/ToolSwitcher.vue
+++ b/fasolt.client/src/components/ToolSwitcher.vue
@@ -91,18 +91,18 @@ async function copyMcpUrl() {
 <template>
   <div>
     <Tabs v-model="tab" class="w-full">
-      <TabsList class="bg-card/60 border border-border/60 rounded-md p-1 gap-1">
+      <TabsList class="bg-paper-2 rounded-md p-1 gap-1">
         <TabsTrigger value="chatgpt" class="text-xs px-3">ChatGPT</TabsTrigger>
         <TabsTrigger value="claude" class="text-xs px-3">Claude</TabsTrigger>
         <TabsTrigger value="mistral" class="text-xs px-3">Mistral</TabsTrigger>
-        <TabsTrigger value="other" class="text-xs px-3 text-muted-foreground/70 data-[state=active]:text-foreground">Other</TabsTrigger>
+        <TabsTrigger value="other" class="text-xs px-3 text-ink-2 data-[state=active]:text-ink-0">Other</TabsTrigger>
       </TabsList>
 
       <!-- ChatGPT -->
       <TabsContent value="chatgpt" class="mt-4">
         <div
-          class="flex flex-col overflow-hidden rounded-xl border border-border/60 shadow-2xl glow-accent-lg lg:h-[420px]"
-          style="background: #ffffff; font-family: 'Söhne', 'Inter', system-ui, -apple-system, sans-serif;"
+          class="flex flex-col overflow-hidden rounded-xl border lg:h-[420px]"
+          style="background: #ffffff; border-color: var(--rule-1); box-shadow: var(--sh-2); font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;"
         >
           <!-- Window chrome -->
           <div class="flex items-center gap-2 px-4 py-3 border-b" style="border-color: #ececec; background: #f9f9f9;">
@@ -136,9 +136,9 @@ async function copyMcpUrl() {
               </div>
               <div class="flex-1 leading-relaxed">
                 <div v-if="phase === 'thinking'" class="flex gap-1 items-center pt-1.5" style="color: #8e8ea0">
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #8e8ea0;"></span>
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #8e8ea0; animation-delay: 0.15s;"></span>
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #8e8ea0; animation-delay: 0.3s;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #8e8ea0;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #8e8ea0; opacity: 0.6;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #8e8ea0; opacity: 0.35;"></span>
                 </div>
                 <template v-else>
                   <p class="mb-3">I'll create flashcards from your notes on LLM basics:</p>
@@ -169,8 +169,8 @@ async function copyMcpUrl() {
       <!-- Claude -->
       <TabsContent value="claude" class="mt-4">
         <div
-          class="flex flex-col overflow-hidden rounded-xl border border-border/60 shadow-2xl glow-accent-lg lg:h-[420px]"
-          style="background: #faf9f5; font-family: 'Styrene B', 'Inter', system-ui, -apple-system, sans-serif;"
+          class="flex flex-col overflow-hidden rounded-xl border lg:h-[420px]"
+          style="background: #faf9f5; border-color: var(--rule-1); box-shadow: var(--sh-2); font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;"
         >
           <!-- Window chrome -->
           <div class="flex items-center gap-2 px-4 py-3 border-b" style="border-color: #e8e6dc; background: #f5f3eb;">
@@ -207,9 +207,9 @@ async function copyMcpUrl() {
               </div>
               <div class="flex-1 leading-relaxed">
                 <div v-if="phase === 'thinking'" class="flex gap-1 items-center pt-1.5" style="color: #91918b">
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #d97757;"></span>
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #d97757; animation-delay: 0.15s;"></span>
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #d97757; animation-delay: 0.3s;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #d97757;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #d97757; opacity: 0.6;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #d97757; opacity: 0.35;"></span>
                 </div>
                 <template v-else>
                   <p class="mb-3">Here are flashcards from your LLM basics notes:</p>
@@ -240,8 +240,8 @@ async function copyMcpUrl() {
       <!-- Mistral Le Chat -->
       <TabsContent value="mistral" class="mt-4">
         <div
-          class="flex flex-col overflow-hidden rounded-xl border border-border/60 shadow-2xl glow-accent-lg lg:h-[420px]"
-          style="background: #faf6f1; font-family: 'Inter', system-ui, -apple-system, sans-serif;"
+          class="flex flex-col overflow-hidden rounded-xl border lg:h-[420px]"
+          style="background: #faf6f1; border-color: var(--rule-1); box-shadow: var(--sh-2); font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;"
         >
           <!-- Window chrome -->
           <div class="flex items-center gap-2 px-4 py-3 border-b" style="border-color: #e9e1d4; background: #f3ede2;">
@@ -284,9 +284,9 @@ async function copyMcpUrl() {
               </div>
               <div class="flex-1 leading-relaxed">
                 <div v-if="phase === 'thinking'" class="flex gap-1 items-center pt-1.5" style="color: #8b7e6a">
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #fa520f;"></span>
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #fa520f; animation-delay: 0.15s;"></span>
-                  <span class="inline-block w-1.5 h-1.5 rounded-full animate-pulse" style="background: #fa520f; animation-delay: 0.3s;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #fa520f;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #fa520f; opacity: 0.6;"></span>
+                  <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: #fa520f; opacity: 0.35;"></span>
                 </div>
                 <template v-else>
                   <p class="mb-3">Voilà — flashcards from your LLM basics notes:</p>
@@ -316,16 +316,17 @@ async function copyMcpUrl() {
 
       <!-- Other / Developers -->
       <TabsContent value="other" class="mt-4">
-        <div class="mb-3 rounded-md border border-border/60 bg-card/60 px-4 py-3 font-mono text-[12px]">
-          <div class="mb-1.5 flex items-center gap-2 text-[10px] uppercase tracking-[0.2em] text-accent/80">
-            <span class="inline-block h-1.5 w-1.5 rounded-full bg-accent animate-pulse"></span>
+        <div class="mb-3 rounded-md border bg-paper-1 px-4 py-3" style="border-color: var(--rule-1);">
+          <div class="fa-cap mb-1.5 flex items-center gap-2">
+            <span class="fa-pulse"></span>
             Connect your agent to the MCP
           </div>
-          <div class="flex items-center gap-2">
-            <span class="text-muted-foreground">$</span>
-            <code class="flex-1 select-all break-all text-foreground">https://fasolt.app/mcp</code>
+          <div class="fa-mono flex items-center gap-2 text-[12px]">
+            <span class="text-ink-2">$</span>
+            <code class="flex-1 select-all break-all text-ink-0">https://fasolt.app/mcp</code>
             <button
-              class="rounded border border-border/60 px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground hover:border-accent/50 transition-colors"
+              class="fa-mono rounded border px-2 py-0.5 text-[10px] text-ink-1 hover:text-ink-0"
+              style="border-color: var(--rule-1);"
               type="button"
               @click="copyMcpUrl"
             >
@@ -334,14 +335,14 @@ async function copyMcpUrl() {
           </div>
         </div>
         <TerminalDemo />
-        <p class="mt-3 text-xs text-muted-foreground">
+        <p class="mt-3 text-xs text-ink-2">
           Streamable HTTP transport. Works with Claude Code, Cursor, and any MCP-compatible client.
         </p>
       </TabsContent>
     </Tabs>
 
-    <p class="mt-4 text-xs text-muted-foreground">
-      <RouterLink to="/mcp-setup" class="text-accent hover:underline">How to connect →</RouterLink>
+    <p class="mt-4 text-xs text-ink-2">
+      <RouterLink to="/mcp-setup" class="text-accent-text hover:underline">How to connect →</RouterLink>
     </p>
   </div>
 </template>

--- a/fasolt.client/src/components/TopBar.vue
+++ b/fasolt.client/src/components/TopBar.vue
@@ -227,7 +227,7 @@ async function handleLogout() { await auth.logout(); window.location.href = '/' 
   color: var(--accent-on);
   display: grid;
   place-items: center;
-  font-family: 'Geist Mono', monospace;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
   font-size: 11px;
   font-weight: 600;
 }

--- a/fasolt.client/src/components/ui/button/index.ts
+++ b/fasolt.client/src/components/ui/button/index.ts
@@ -8,15 +8,17 @@ export const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        // Primary action keeps the brand accent (flat, no gloss).
+        default: "bg-accent text-accent-foreground hover:bg-accent-hi",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        // Generic ghost/outline hover uses a quiet surface, not brand accent.
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background text-foreground hover:bg-muted",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-secondary text-secondary-foreground hover:bg-muted",
+        ghost: "text-foreground hover:bg-muted",
+        link: "text-accent-text underline-offset-4 hover:underline",
       },
       size: {
         "default": "h-10 px-4 py-2",

--- a/fasolt.client/src/components/ui/card/Card.vue
+++ b/fasolt.client/src/components/ui/card/Card.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   <div
     :class="
       cn(
-        'rounded-lg border bg-card text-card-foreground shadow-sm',
+        'rounded-xl border bg-card text-card-foreground shadow-[var(--sh-2)]',
         props.class,
       )
     "

--- a/fasolt.client/src/components/ui/checkbox/Checkbox.vue
+++ b/fasolt.client/src/components/ui/checkbox/Checkbox.vue
@@ -18,7 +18,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
   <CheckboxRoot
     v-bind="forwarded"
     :class="
-      cn('grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      cn('grid place-content-center peer h-4 w-4 shrink-0 rounded-[5px] border border-ink-3 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-accent data-[state=checked]:bg-accent data-[state=checked]:text-accent-foreground',
          props.class)"
   >
     <CheckboxIndicator class="grid place-content-center text-current">

--- a/fasolt.client/src/components/ui/dialog/DialogContent.vue
+++ b/fasolt.client/src/components/ui/dialog/DialogContent.vue
@@ -29,14 +29,14 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-bind="forwarded"
       :class="
         cn(
-          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-[var(--sh-2)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
           props.class,
         )"
     >
       <slot />
 
       <DialogClose
-        class="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+        class="absolute right-4 top-4 rounded-md p-0.5 text-ink-2 ring-offset-background transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
       >
         <X class="w-4 h-4" />
         <span class="sr-only">Close</span>

--- a/fasolt.client/src/components/ui/dialog/DialogScrollContent.vue
+++ b/fasolt.client/src/components/ui/dialog/DialogScrollContent.vue
@@ -28,7 +28,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       <DialogContent
         :class="
           cn(
-            'relative z-50 grid w-full max-w-lg my-8 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-lg md:w-full',
+            'relative z-50 grid w-full max-w-lg my-8 gap-4 border border-border bg-background p-6 shadow-[var(--sh-2)] duration-200 sm:rounded-lg md:w-full',
             props.class,
           )
         "
@@ -44,7 +44,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
         <slot />
 
         <DialogClose
-          class="absolute top-3 right-3 p-0.5 transition-colors rounded-md hover:bg-secondary"
+          class="absolute top-3 right-3 p-0.5 text-ink-2 transition-colors rounded-md hover:bg-muted hover:text-foreground"
         >
           <X class="w-4 h-4" />
           <span class="sr-only">Close</span>

--- a/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuCheckboxItem.vue
+++ b/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuCheckboxItem.vue
@@ -22,7 +22,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
   <DropdownMenuCheckboxItem
     v-bind="forwarded"
     :class=" cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       props.class,
     )"
   >

--- a/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuContent.vue
+++ b/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuContent.vue
@@ -26,7 +26,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
   <DropdownMenuPortal>
     <DropdownMenuContent
       v-bind="forwarded"
-      :class="cn('z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)"
+      :class="cn('z-50 min-w-32 overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-[var(--sh-2)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)"
     >
       <slot />
     </DropdownMenuContent>

--- a/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuItem.vue
+++ b/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuItem.vue
@@ -16,7 +16,7 @@ const forwardedProps = useForwardProps(delegatedProps)
   <DropdownMenuItem
     v-bind="forwardedProps"
     :class="cn(
-      'relative flex cursor-default select-none items-center rounded-sm gap-2 px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+      'relative flex cursor-default select-none items-center rounded-sm gap-2 px-2 py-1.5 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
       inset && 'pl-8',
       props.class,
     )"

--- a/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuRadioItem.vue
+++ b/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuRadioItem.vue
@@ -23,7 +23,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
   <DropdownMenuRadioItem
     v-bind="forwarded"
     :class="cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-muted focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       props.class,
     )"
   >

--- a/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuShortcut.vue
+++ b/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuShortcut.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
 </script>
 
 <template>
-  <span :class="cn('ml-auto text-xs tracking-widest opacity-60', props.class)">
+  <span :class="cn('ml-auto text-xs text-ink-2', props.class)">
     <slot />
   </span>
 </template>

--- a/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuSubContent.vue
+++ b/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuSubContent.vue
@@ -19,7 +19,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 <template>
   <DropdownMenuSubContent
     v-bind="forwarded"
-    :class="cn('z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)"
+    :class="cn('z-50 min-w-32 overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-[var(--sh-2)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)"
   >
     <slot />
   </DropdownMenuSubContent>

--- a/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuSubTrigger.vue
+++ b/fasolt.client/src/components/ui/dropdown-menu/DropdownMenuSubTrigger.vue
@@ -20,7 +20,7 @@ const forwardedProps = useForwardProps(delegatedProps)
   <DropdownMenuSubTrigger
     v-bind="forwardedProps"
     :class="cn(
-      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-muted data-[state=open]:bg-muted',
       props.class,
     )"
   >

--- a/fasolt.client/src/components/ui/progress/Progress.vue
+++ b/fasolt.client/src/components/ui/progress/Progress.vue
@@ -29,7 +29,7 @@ const delegatedProps = reactiveOmit(props, "class")
     "
   >
     <ProgressIndicator
-      class="h-full w-full flex-1 bg-primary transition-all"
+      class="h-full w-full flex-1 bg-accent transition-all"
       :style="`transform: translateX(-${100 - (props.modelValue ?? 0)}%);`"
     />
   </ProgressRoot>

--- a/fasolt.client/src/components/ui/tabs/TabsTrigger.vue
+++ b/fasolt.client/src/components/ui/tabs/TabsTrigger.vue
@@ -16,7 +16,7 @@ const forwardedProps = useForwardProps(delegatedProps)
   <TabsTrigger
     v-bind="forwardedProps"
     :class="cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-[var(--sh-2)]',
       props.class,
     )"
   >

--- a/fasolt.client/src/components/ui/tooltip/TooltipContent.vue
+++ b/fasolt.client/src/components/ui/tooltip/TooltipContent.vue
@@ -22,7 +22,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 
 <template>
   <TooltipPortal>
-    <TooltipContent v-bind="{ ...forwarded, ...$attrs }" :class="cn('z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)">
+    <TooltipContent v-bind="{ ...forwarded, ...$attrs }" :class="cn('z-50 overflow-hidden rounded-lg border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-[var(--sh-2)] animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)">
       <slot />
     </TooltipContent>
   </TooltipPortal>

--- a/fasolt.client/src/layouts/AdminLayout.vue
+++ b/fasolt.client/src/layouts/AdminLayout.vue
@@ -5,44 +5,100 @@ import { useRoute, RouterLink, RouterView } from 'vue-router'
 const route = useRoute()
 
 const sections = [
-  { label: 'Overview', to: '/admin/overview', icon: '▦' },
-  { label: 'Users', to: '/admin/users', icon: '☲' },
-  { label: 'Activity', to: '/admin/logs', icon: '◫' },
+  { label: 'Overview', to: '/admin/overview' },
+  { label: 'Users', to: '/admin/users' },
+  { label: 'Activity', to: '/admin/logs' },
 ]
 
 const activePath = computed(() => route.path)
 </script>
 
 <template>
-  <div class="space-y-4">
-    <div>
-      <h1 class="text-2xl font-bold tracking-tight">Admin</h1>
-      <p class="text-muted-foreground">Manage users and monitor usage.</p>
+  <div class="admin-shell">
+    <div class="admin-head">
+      <h1 class="page-title">Admin</h1>
+      <p class="admin-sub">Manage users and monitor usage.</p>
     </div>
 
-    <div class="flex flex-col gap-6 md:flex-row">
-      <aside class="md:w-56 md:shrink-0">
-        <nav class="flex gap-1 overflow-x-auto md:flex-col md:gap-0.5">
+    <div class="admin-body">
+      <aside class="admin-aside">
+        <nav class="admin-nav">
           <RouterLink
             v-for="s in sections"
             :key="s.to"
             :to="s.to"
-            :class="[
-              'flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors whitespace-nowrap',
-              activePath === s.to || activePath.startsWith(s.to + '/')
-                ? 'bg-muted font-medium text-foreground'
-                : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-            ]"
+            class="admin-nav-item"
+            :class="{ 'is-active': activePath === s.to || activePath.startsWith(s.to + '/') }"
           >
-            <span class="text-base leading-none" aria-hidden>{{ s.icon }}</span>
-            <span>{{ s.label }}</span>
+            {{ s.label }}
           </RouterLink>
         </nav>
       </aside>
 
-      <section class="min-w-0 flex-1">
+      <section class="admin-content">
         <RouterView />
       </section>
     </div>
   </div>
 </template>
+
+<style scoped>
+.admin-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 32px 8px 48px;
+  max-width: 1100px;
+  margin: 0 auto;
+  width: 100%;
+}
+.page-title { font-size: 28px; }
+.admin-sub {
+  margin: 6px 0 0;
+  color: var(--ink-2);
+  font-size: 14px;
+}
+
+.admin-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+@media (min-width: 768px) {
+  .admin-body { flex-direction: row; gap: 32px; }
+}
+
+.admin-aside { flex-shrink: 0; }
+@media (min-width: 768px) {
+  .admin-aside { width: 200px; }
+}
+
+.admin-nav {
+  display: flex;
+  gap: 2px;
+  overflow-x: auto;
+}
+@media (min-width: 768px) {
+  .admin-nav { flex-direction: column; gap: 1px; }
+}
+
+.admin-nav-item {
+  display: flex;
+  align-items: center;
+  padding: 7px 12px;
+  border-radius: 8px;
+  font-size: 14px;
+  color: var(--ink-1);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background .12s, color .12s;
+}
+.admin-nav-item:hover { background: var(--paper-2); color: var(--ink-0); }
+.admin-nav-item.is-active {
+  background: var(--paper-2);
+  color: var(--ink-0);
+  font-weight: 600;
+}
+
+.admin-content { min-width: 0; flex: 1; }
+</style>

--- a/fasolt.client/src/style.css
+++ b/fasolt.client/src/style.css
@@ -3,40 +3,45 @@
 @tailwind utilities;
 
 /* ---------------------------------------------------------------------------
-   Fasolt design system — paper & ink, vermilion accent.
-   Tokens use OKLCH so they read well across light/dark and look honest.
-   Three type voices: Geist (chrome), Geist Mono (data/IDs), Instrument Serif (moments).
+   fasolt design language — "Quiet & Functional" (Things-anchored).
+   System font for all UI (Geist is reserved for the wordmark logotype only).
+   One warm marigold accent, used sparingly. Whitespace over borders. No gloss.
+   See docs/superpowers/specs/2026-06-13-things-design-language.md
    --------------------------------------------------------------------------- */
 
 @layer base {
   :root {
-    /* paper + ink (light) */
-    --paper-0: oklch(0.985 0.004 75);   /* page bg */
-    --paper-1: oklch(0.970 0.005 75);   /* surface / card */
-    --paper-2: oklch(0.945 0.006 75);   /* sunken / stripe */
-    --rule-1:  oklch(0.905 0.006 75);   /* hairline border */
-    --rule-2:  oklch(0.925 0.005 75);
-    --ink-0:   oklch(0.18  0.012 60);   /* primary text */
-    --ink-1:   oklch(0.36  0.011 60);   /* secondary text */
-    --ink-2:   oklch(0.55  0.008 60);   /* muted */
-    --ink-3:   oklch(0.72  0.005 75);   /* most muted */
-    --accent:  oklch(0.61  0.17 40);    /* vermilion */
-    --accent-hi: oklch(0.55 0.18 38);
-    --accent-soft: oklch(0.945 0.045 55);
-    --accent-on: #ffffff;
+    /* paper + ink (light) — white page, hairlines + air do the structuring */
+    --paper-0: #ffffff;   /* page bg */
+    --paper-1: #ffffff;   /* surface / card (defined by hairline, not fill) */
+    --paper-2: #f4f4f3;   /* sunken / hover / input fill / stripe */
+    --rule-1:  #ececec;   /* hairline border */
+    --rule-2:  #f2f2f2;   /* faintest rule */
+    --ink-0:   #1c1c1e;   /* primary text */
+    --ink-1:   #6b6b70;   /* secondary text */
+    --ink-2:   #8e8e93;   /* muted / quiet labels */
+    --ink-3:   #c2c2c7;   /* tertiary (chevrons, ring tracks) */
 
-    /* status (Again / Hard / Good / Easy) */
-    --c-again: oklch(0.60 0.18 25);
-    --c-hard:  oklch(0.65 0.16 65);
-    --c-good:  oklch(0.55 0.13 155);
-    --c-easy:  oklch(0.55 0.14 245);
+    /* brand marigold accent */
+    --accent:      #ee9b42;  /* fills, rings, active, "today" */
+    --accent-hi:   #e08f31;  /* accent hover / pressed */
+    --accent-text: #c9781a;  /* accent as text/links on light (AA-legible) */
+    --accent-soft: #fbeede;  /* accent tint background */
+    --accent-on:   #ffffff;  /* text/icon on an accent fill */
 
-    /* shadows */
-    --sh-1: 0 1px 0 oklch(0.90 0.005 75 / .6);
-    --sh-2: 0 1px 2px oklch(0.20 0.01 60 / .04), 0 4px 16px oklch(0.20 0.01 60 / .04);
+    /* status (Again / Hard / Good / Easy) — Apple system hues; Hard leans amber
+       so the four rating buttons stay distinct from the brand marigold */
+    --c-again: #ff3b30;
+    --c-hard:  #f5b400;
+    --c-good:  #34c759;
+    --c-easy:  #2e7cf6;
 
-    /* tailwind-compat: shadcn used hsl(var(--background)) etc. We point those
-       at the new palette so legacy classes still hit a sensible color. */
+    /* shadows — at most a whisper */
+    --sh-1: 0 1px 0 rgba(0,0,0,.02);
+    --sh-2: 0 1px 3px rgba(0,0,0,.05);
+
+    /* tailwind-compat: shadcn used hsl(var(--background)) etc. Point those at the
+       palette so legacy classes still hit a sensible color. */
     --background: var(--paper-0);
     --foreground: var(--ink-0);
     --card: var(--paper-1);
@@ -54,37 +59,40 @@
     --destructive: var(--c-again);
     --destructive-foreground: #ffffff;
     --warning: var(--c-hard);
-    --warning-foreground: #ffffff;
+    --warning-foreground: #1c1c1e;
     --success: var(--c-good);
     --success-foreground: #ffffff;
     --border: var(--rule-1);
     --input: var(--rule-1);
     --ring: var(--accent);
-    --radius: 0.5rem;
+    --radius: 0.625rem;
   }
 
   .dark {
-    --paper-0: oklch(0.155 0.008 60);
-    --paper-1: oklch(0.185 0.009 60);
-    --paper-2: oklch(0.220 0.010 60);
-    --rule-1:  oklch(0.275 0.010 60);
-    --rule-2:  oklch(0.240 0.009 60);
-    --ink-0:   oklch(0.96  0.005 75);
-    --ink-1:   oklch(0.78  0.007 75);
-    --ink-2:   oklch(0.60  0.008 75);
-    --ink-3:   oklch(0.42  0.008 75);
-    --accent:  oklch(0.70  0.17 42);
-    --accent-hi: oklch(0.77 0.17 42);
-    --accent-soft: oklch(0.25 0.07 45);
-    --accent-on: oklch(0.13 0.01 60);
+    /* warm charcoal — flat, no heavy panels */
+    --paper-0: #1b1b1c;
+    --paper-1: #242427;
+    --paper-2: #2f2f33;
+    --rule-1:  #34343a;
+    --rule-2:  #2c2c30;
+    --ink-0:   #ededf0;
+    --ink-1:   #a8a8af;
+    --ink-2:   #8a8a91;
+    --ink-3:   #5c5c63;
 
-    --c-again: oklch(0.70 0.20 25);
-    --c-hard:  oklch(0.78 0.16 70);
-    --c-good:  oklch(0.70 0.15 155);
-    --c-easy:  oklch(0.72 0.14 245);
+    --accent:      #f2a352;
+    --accent-hi:   #f4ad63;
+    --accent-text: #f2a352;
+    --accent-soft: #3a2c1a;
+    --accent-on:   #ffffff;
 
-    --sh-1: 0 1px 0 oklch(0 0 0 / .35);
-    --sh-2: 0 1px 2px #000a, 0 8px 28px #0006;
+    --c-again: #ff453a;
+    --c-hard:  #ffcc33;
+    --c-good:  #30d158;
+    --c-easy:  #4a9bff;
+
+    --sh-1: 0 1px 0 rgba(0,0,0,.2);
+    --sh-2: 0 1px 3px rgba(0,0,0,.3);
   }
 }
 
@@ -92,11 +100,9 @@
   * { border-color: var(--rule-1); }
   html, body { background: var(--paper-0); color: var(--ink-0); }
   body {
-    font-family: 'Geist', system-ui, -apple-system, 'Segoe UI', sans-serif;
-    font-feature-settings: 'ss01','ss02','cv01','cv11';
+    font-family: -apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', Roboto, sans-serif;
     font-size: 14px;
     line-height: 1.5;
-    letter-spacing: -0.005em;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -110,49 +116,52 @@
     padding: 0 2px;
   }
 
-  button, a, input, select, textarea { transition: color .15s, background .15s, border-color .15s; }
+  button, a, input, select, textarea { transition: color .12s, background .12s, border-color .12s; }
 }
 
 /* ---------------------------------------------------------------------------
    Type roles & atomic helpers
    --------------------------------------------------------------------------- */
 @layer components {
-  .fa-sans  { font-family: 'Geist', system-ui, sans-serif; }
-  .fa-mono  { font-family: 'Geist Mono', ui-monospace, 'JetBrains Mono', monospace; font-feature-settings: 'ss01','ss02','zero'; }
-  .fa-serif { font-family: 'Instrument Serif', 'Times New Roman', serif; letter-spacing: -0.01em; }
+  .fa-sans  { font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif; }
+  .fa-mono  { font-family: ui-monospace, 'SF Mono', Menlo, monospace; }
+  /* The serif "moment" voice is retired; map to the system font so any leftover
+     usage stays consistent rather than dropping to Times. */
+  .fa-serif { font-family: inherit; }
 
-  /* Page H1 — shares the wordmark's typography (Geist 600, tight). */
+  /* Page H1 — clean system, tight. */
   .page-title {
-    font-family: 'Geist', system-ui, sans-serif;
-    font-size: 34px;
+    font-family: inherit;
+    font-size: 32px;
     font-weight: 600;
-    line-height: 1;
-    letter-spacing: -0.045em;
+    line-height: 1.05;
+    letter-spacing: -0.03em;
     margin: 0;
     color: var(--ink-0);
   }
 
-  /* Numerals — by default a clean tabular sans. */
+  /* Numerals — clean tabular system. */
   .fa-num {
-    font-family: 'Geist', system-ui, sans-serif;
-    font-feature-settings: 'tnum' 1, 'lnum' 1, 'ss01' 1;
+    font-feature-settings: 'tnum' 1, 'lnum' 1;
     font-variant-numeric: tabular-nums lining-nums;
     font-weight: 500;
     letter-spacing: -0.02em;
   }
+  /* Retired serif numerals → system tabular (class kept for compatibility). */
   .fa-num-serif {
-    font-family: 'Instrument Serif', serif;
     font-variant-numeric: tabular-nums lining-nums;
-    font-weight: 400;
-    letter-spacing: -0.025em;
+    font-weight: 600;
+    letter-spacing: -0.02em;
   }
 
-  /* Small-caps mono labels — the spine of the system */
+  /* Quiet section label — replaces the old uppercase wide-tracked mono caps.
+     Sentence case, system font, muted. The spine of the calmed system. */
   .fa-cap {
-    font-family: 'Geist Mono', ui-monospace, monospace;
-    text-transform: uppercase;
-    font-size: 10px;
-    letter-spacing: 0.18em;
+    font-family: inherit;
+    text-transform: none;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0;
     color: var(--ink-2);
   }
 
@@ -160,7 +169,7 @@
   .fa-kbd {
     display: inline-flex; align-items: center; justify-content: center;
     min-width: 18px; height: 18px; padding: 0 5px;
-    font-family: 'Geist Mono', ui-monospace, monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
     font-size: 10.5px; line-height: 1; letter-spacing: 0;
     color: var(--ink-1);
     background: var(--paper-1);
@@ -180,64 +189,55 @@
     border-bottom: 1px solid var(--rule-1);
     transition: color .12s, border-color .12s;
   }
-  .fa-link:hover { color: var(--accent); border-color: var(--accent); }
+  .fa-link:hover { color: var(--accent-text); border-color: var(--accent); }
 
-  /* Pulsing accent dot — used for active states. Color tracks --accent so
-     light/dark stay in sync (currentColor in the halo picks up the dot's
-     accent fill, so the ring matches the dot in both themes). */
+  /* Accent dot — static, used for active states. No pulse/glow (de-glossed). */
   .fa-pulse {
     display: inline-block;
     width: 6px; height: 6px;
     border-radius: 50%;
     background: var(--accent);
-    color: var(--accent);
-    box-shadow: 0 0 0 0 currentColor;
-    animation: faPulse 1.6s infinite;
-  }
-  @keyframes faPulse {
-    0%   { box-shadow: 0 0 0 0 color-mix(in oklch, currentColor 55%, transparent); }
-    70%  { box-shadow: 0 0 0 8px color-mix(in oklch, currentColor 0%, transparent); }
-    100% { box-shadow: 0 0 0 0 color-mix(in oklch, currentColor 0%, transparent); }
   }
 
   /* Deck color swatch */
-  .fa-tag { display: inline-block; width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
+  .fa-tag { display: inline-block; width: 8px; height: 8px; border-radius: 999px; flex-shrink: 0; }
 
   /* Striped placeholder (used for "new deck" empty card) */
   .fa-stripe-bg {
     background-image: repeating-linear-gradient(135deg, var(--rule-2) 0 1px, transparent 1px 8px);
   }
 
-  /* Buttons — same shape language as inline .fa-btn from the design canvas */
+  /* Buttons */
   .fa-btn {
     display: inline-flex; align-items: center; justify-content: center;
     gap: 8px;
-    padding: 0 12px; height: 32px;
-    border-radius: 6px;
+    padding: 0 13px; height: 32px;
+    border-radius: 9px;
     border: 1px solid var(--rule-1);
     background: var(--paper-1);
     color: var(--ink-0);
     font-size: 13px; font-weight: 500;
     font-family: inherit;
     cursor: pointer;
-    transition: background .12s, border-color .12s, transform .08s, color .12s;
+    transition: background .12s, border-color .12s, color .12s;
     white-space: nowrap;
   }
   .fa-btn:hover { background: var(--paper-2); border-color: var(--ink-3); }
-  .fa-btn:active { transform: translateY(1px); }
   .fa-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  /* Primary — flat marigold, no gloss. */
   .fa-btn-primary {
     background: var(--accent);
     color: var(--accent-on);
-    border-color: var(--accent-hi);
-    box-shadow: inset 0 1px 0 oklch(1 0 0 / .18), 0 1px 2px oklch(0.4 0.16 40 / .25);
+    border-color: var(--accent);
+    font-weight: 600;
   }
   .fa-btn-primary:hover { background: var(--accent-hi); border-color: var(--accent-hi); color: var(--accent-on); }
   .fa-btn-ghost { background: transparent; border-color: transparent; }
-  .fa-btn-ghost:hover { background: var(--paper-1); border-color: var(--rule-1); }
+  .fa-btn-ghost:hover { background: var(--paper-2); border-color: transparent; }
   .fa-btn-accent {
-    color: var(--accent);
+    color: var(--accent-text);
     border-color: var(--accent);
+    background: transparent;
   }
   .fa-btn-accent:hover { background: var(--accent-soft); }
 
@@ -263,21 +263,21 @@
   /* Chip — small data tag */
   .fa-chip {
     display: inline-flex; align-items: center; gap: 6px;
-    height: 22px; padding: 0 8px;
-    font-size: 11px; font-family: 'Geist Mono', monospace;
+    height: 22px; padding: 0 9px;
+    font-size: 11.5px;
     color: var(--ink-1);
     background: var(--paper-1);
     border: 1px solid var(--rule-1);
     border-radius: 999px;
   }
 
-  /* Surface card (replaces shadcn Card visuals) */
+  /* Surface card */
   .fa-surface {
     border: 1px solid var(--rule-1);
-    border-radius: 10px;
+    border-radius: 12px;
     background: var(--paper-1);
   }
-  .fa-surface-lg { border-radius: 12px; }
+  .fa-surface-lg { border-radius: 14px; }
 
   /* Markdown prose tuned to the system */
   .fa-prose { color: var(--ink-1); font-size: 15px; line-height: 1.6; }
@@ -285,7 +285,7 @@
   .fa-prose strong { font-weight: 600; color: var(--ink-0); }
   .fa-prose em { font-style: italic; }
   .fa-prose code {
-    font-family: 'Geist Mono', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
     font-size: 0.92em;
     padding: 1px 5px;
     background: var(--paper-2);
@@ -298,14 +298,14 @@
     padding: 12px 14px;
     background: var(--paper-2);
     border: 1px solid var(--rule-1);
-    border-radius: 6px;
+    border-radius: 8px;
     overflow-x: auto;
   }
   .fa-prose pre code { padding: 0; background: transparent; border: none; }
   .fa-prose h1, .fa-prose h2, .fa-prose h3, .fa-prose h4 {
-    font-family: 'Geist', sans-serif;
+    font-family: inherit;
     color: var(--ink-0);
-    line-height: 1.2;
+    line-height: 1.25;
     margin: 1em 0 .4em;
     letter-spacing: -0.01em;
   }
@@ -315,7 +315,7 @@
   .fa-prose ul, .fa-prose ol { padding-left: 1.4em; margin: 0 0 .6em; }
   .fa-prose li { margin: .2em 0; }
   .fa-prose a {
-    color: var(--accent);
+    color: var(--accent-text);
     text-decoration: none;
     border-bottom: 1px solid var(--accent-soft);
   }
@@ -340,6 +340,7 @@
   .text-ink-2 { color: var(--ink-2); }
   .text-ink-3 { color: var(--ink-3); }
   .text-accent { color: var(--accent); }
+  .text-accent-text { color: var(--accent-text); }
   .bg-accent  { background: var(--accent); }
   .border-rule-1 { border-color: var(--rule-1); }
   .border-rule-2 { border-color: var(--rule-2); }

--- a/fasolt.client/src/style.css
+++ b/fasolt.client/src/style.css
@@ -191,6 +191,15 @@
   }
   .fa-link:hover { color: var(--accent-text); border-color: var(--accent); }
 
+  /* Single quiet back link — replaces multi-part breadcrumb trails. */
+  .fa-back {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-size: 13px; color: var(--ink-2);
+    text-decoration: none; transition: color .12s;
+  }
+  .fa-back:hover { color: var(--ink-0); }
+  .fa-back svg { width: 14px; height: 14px; }
+
   /* Accent dot — static, used for active states. No pulse/glow (de-glossed). */
   .fa-pulse {
     display: inline-block;

--- a/fasolt.client/src/views/AlgorithmView.vue
+++ b/fasolt.client/src/views/AlgorithmView.vue
@@ -1,186 +1,312 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import AppFooter from '@/components/AppFooter.vue'
 import FasoltWordmark from '@/components/FasoltWordmark.vue'
 import ThemeToggle from '@/components/ThemeToggle.vue'
+
+const intervals = ['1d', '3d', '8d', '21d', '55d', '4mo']
 </script>
 
 <template>
-  <div class="flex min-h-screen flex-col bg-background text-foreground">
+  <div class="algo-page">
     <!-- Nav -->
-    <nav class="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-md">
-      <div class="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+    <nav class="nav">
+      <div class="nav-inner">
         <RouterLink to="/" class="flex items-center">
           <FasoltWordmark :size="32" />
         </RouterLink>
         <div class="flex items-center gap-2">
           <ThemeToggle />
-          <a href="/login">
-            <Button variant="ghost" size="sm" class="text-sm">Log in</Button>
-          </a>
+          <a href="/login" class="fa-btn fa-btn-ghost">Log in</a>
         </div>
       </div>
     </nav>
 
     <!-- Content -->
-    <main class="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
-      <div class="space-y-8">
-        <div>
-          <h1 class="text-lg font-semibold tracking-tight">How the Algorithm Works</h1>
-          <p class="text-sm text-muted-foreground mt-1">
-            fasolt uses FSRS (Free Spaced Repetition Scheduler) to schedule your reviews.
+    <main class="main">
+      <header class="page-head">
+        <h1 class="page-title">How the algorithm works</h1>
+        <p class="page-lede">
+          fasolt uses FSRS (Free Spaced Repetition Scheduler) to schedule your reviews.
+        </p>
+      </header>
+
+      <!-- What is Spaced Repetition -->
+      <section class="block">
+        <h2 class="block-title">What is spaced repetition?</h2>
+        <div class="fa-prose">
+          <p>
+            <a href="https://en.wikipedia.org/wiki/Spaced_repetition" target="_blank" rel="noopener noreferrer">Spaced repetition</a> is a study technique where you review material at increasing intervals.
+            Instead of cramming, you see a card right before you're likely to forget it.
+            Each successful recall makes the memory stronger, so the next review can wait longer.
+          </p>
+          <p>
+            A new card might be reviewed after 1 day, then 3 days, then 8 days, then 3 weeks —
+            growing exponentially as the memory stabilizes. This exploits the
+            <a href="https://en.wikipedia.org/wiki/Forgetting_curve" target="_blank" rel="noopener noreferrer">forgetting curve</a>
+            discovered by Hermann Ebbinghaus in the 1880s.
           </p>
         </div>
+      </section>
 
-        <!-- What is Spaced Repetition -->
-        <Card class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-sm">What is Spaced Repetition?</CardTitle>
-          </CardHeader>
-          <CardContent class="text-sm text-muted-foreground leading-relaxed space-y-3">
-            <p>
-              <a href="https://en.wikipedia.org/wiki/Spaced_repetition" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">Spaced repetition</a> is a study technique where you review material at increasing intervals.
-              Instead of cramming, you see a card right before you're likely to forget it.
-              Each successful recall makes the memory stronger, so the next review can wait longer.
-            </p>
-            <p>
-              A new card might be reviewed after 1 day, then 3 days, then 8 days, then 3 weeks —
-              growing exponentially as the memory stabilizes. This exploits the
-              <a href="https://en.wikipedia.org/wiki/Forgetting_curve" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">forgetting curve</a>
-              discovered by Hermann Ebbinghaus in the 1880s.
-            </p>
-          </CardContent>
-        </Card>
+      <!-- The FSRS Algorithm -->
+      <section class="block">
+        <h2 class="block-title">The FSRS algorithm</h2>
+        <div class="fa-prose">
+          <p>
+            <a href="https://github.com/open-spaced-repetition/fsrs4anki" target="_blank" rel="noopener noreferrer">FSRS</a> (Free Spaced Repetition Scheduler) is a modern, open-source algorithm based on the
+            <strong>Three Component Model of Memory</strong>. It tracks three variables for each card:
+          </p>
+        </div>
+        <dl class="defs">
+          <div class="def">
+            <dt>Stability (S)</dt>
+            <dd>How long the memory lasts. Higher stability means longer intervals between reviews. This is the core scheduling driver.</dd>
+          </div>
+          <div class="def">
+            <dt>Difficulty (D)</dt>
+            <dd>How inherently hard the card is for you. Updated with each review based on your rating.</dd>
+          </div>
+          <div class="def">
+            <dt>Retrievability (R)</dt>
+            <dd>The probability you can recall the card right now. Decays over time — when it drops below the target retention (90%), the card becomes due.</dd>
+          </div>
+        </dl>
+        <div class="fa-prose">
+          <p>
+            Unlike older algorithms that use the same fixed formula for everyone, FSRS's default parameters were
+            optimized on over 700 million reviews from 20,000 users, making it significantly more accurate out of the box.
+          </p>
+        </div>
+      </section>
 
-        <!-- The FSRS Algorithm -->
-        <Card class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-sm">The FSRS Algorithm</CardTitle>
-          </CardHeader>
-          <CardContent class="text-sm text-muted-foreground leading-relaxed space-y-3">
-            <p>
-              <a href="https://github.com/open-spaced-repetition/fsrs4anki" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">FSRS</a> (Free Spaced Repetition Scheduler) is a modern, open-source algorithm based on the
-              <strong class="text-foreground">Three Component Model of Memory</strong>. It tracks three variables for each card:
-            </p>
-            <dl class="space-y-3 pl-1">
-              <div>
-                <dt class="font-medium text-foreground">Stability (S)</dt>
-                <dd>How long the memory lasts. Higher stability means longer intervals between reviews. This is the core scheduling driver.</dd>
-              </div>
-              <div>
-                <dt class="font-medium text-foreground">Difficulty (D)</dt>
-                <dd>How inherently hard the card is for you. Updated with each review based on your rating.</dd>
-              </div>
-              <div>
-                <dt class="font-medium text-foreground">Retrievability (R)</dt>
-                <dd>The probability you can recall the card right now. Decays over time — when it drops below the target retention (90%), the card becomes due.</dd>
-              </div>
-            </dl>
-            <p>
-              Unlike older algorithms that use the same fixed formula for everyone, FSRS's default parameters were
-              optimized on over 700 million reviews from 20,000 users, making it significantly more accurate out of the box.
-            </p>
-          </CardContent>
-        </Card>
-
-        <!-- How Reviews Work -->
-        <Card class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-sm">How Reviews Work</CardTitle>
-          </CardHeader>
-          <CardContent class="text-sm text-muted-foreground leading-relaxed space-y-3">
-            <p>When you review a card, you rate how well you recalled it. Each rating affects the card differently:</p>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div class="rounded border border-border/60 p-3 space-y-1">
-                <div class="font-medium text-foreground">Again</div>
-                <div>You forgot. Stability resets and the card re-enters the learning phase for short-interval reviews.</div>
-              </div>
-              <div class="rounded border border-border/60 p-3 space-y-1">
-                <div class="font-medium text-foreground">Hard</div>
-                <div>You recalled with significant difficulty. Stability increases slightly, difficulty goes up.</div>
-              </div>
-              <div class="rounded border border-border/60 p-3 space-y-1">
-                <div class="font-medium text-foreground">Good</div>
-                <div>Normal recall. Stability increases proportionally, the standard path.</div>
-              </div>
-              <div class="rounded border border-border/60 p-3 space-y-1">
-                <div class="font-medium text-foreground">Easy</div>
-                <div>Effortless recall. Large stability increase, difficulty decreases. Longer until next review.</div>
-              </div>
+      <!-- How Reviews Work -->
+      <section class="block">
+        <h2 class="block-title">How reviews work</h2>
+        <div class="fa-prose">
+          <p>When you review a card, you rate how well you recalled it. Each rating affects the card differently:</p>
+        </div>
+        <ul class="ratings">
+          <li>
+            <span class="rating-dot" :style="{ background: 'var(--c-again)' }" />
+            <div>
+              <div class="rating-name">Again</div>
+              <p>You forgot. Stability resets and the card re-enters the learning phase for short-interval reviews.</p>
             </div>
-          </CardContent>
-        </Card>
-
-        <!-- How Intervals Grow -->
-        <Card class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-sm">How Intervals Grow</CardTitle>
-          </CardHeader>
-          <CardContent class="text-sm text-muted-foreground leading-relaxed space-y-3">
-            <p>Here's a typical progression for a card rated "Good" each time:</p>
-            <div class="flex flex-wrap items-center gap-2 text-foreground font-mono text-xs">
-              <span class="rounded bg-muted/50 px-2 py-1">1d</span>
-              <span class="text-muted-foreground">&rarr;</span>
-              <span class="rounded bg-muted/50 px-2 py-1">3d</span>
-              <span class="text-muted-foreground">&rarr;</span>
-              <span class="rounded bg-muted/50 px-2 py-1">8d</span>
-              <span class="text-muted-foreground">&rarr;</span>
-              <span class="rounded bg-muted/50 px-2 py-1">21d</span>
-              <span class="text-muted-foreground">&rarr;</span>
-              <span class="rounded bg-muted/50 px-2 py-1">55d</span>
-              <span class="text-muted-foreground">&rarr;</span>
-              <span class="rounded bg-muted/50 px-2 py-1">4mo</span>
-              <span class="text-muted-foreground">&rarr;</span>
-              <span class="text-xs">...</span>
+          </li>
+          <li>
+            <span class="rating-dot" :style="{ background: 'var(--c-hard)' }" />
+            <div>
+              <div class="rating-name">Hard</div>
+              <p>You recalled with significant difficulty. Stability increases slightly, difficulty goes up.</p>
             </div>
-            <p>
-              The intervals grow roughly exponentially. If you rate "Easy", they grow even faster.
-              If you rate "Again", the card resets and works its way back up from short intervals.
-            </p>
-          </CardContent>
-        </Card>
+          </li>
+          <li>
+            <span class="rating-dot" :style="{ background: 'var(--c-good)' }" />
+            <div>
+              <div class="rating-name">Good</div>
+              <p>Normal recall. Stability increases proportionally, the standard path.</p>
+            </div>
+          </li>
+          <li>
+            <span class="rating-dot" :style="{ background: 'var(--c-easy)' }" />
+            <div>
+              <div class="rating-name">Easy</div>
+              <p>Effortless recall. Large stability increase, difficulty decreases. Longer until next review.</p>
+            </div>
+          </li>
+        </ul>
+      </section>
 
-        <!-- Why FSRS -->
-        <Card class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-sm">Why FSRS?</CardTitle>
-          </CardHeader>
-          <CardContent class="text-sm text-muted-foreground leading-relaxed space-y-3">
-            <p>
-              FSRS replaced the <a href="https://en.wikipedia.org/wiki/SuperMemo#Description_of_SM-2_algorithm" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">SM-2 algorithm</a> (created in 1987) as the standard for spaced repetition.
-              It's now the default in <a href="https://en.wikipedia.org/wiki/Anki_(software)" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">Anki</a> (since version 23.10), the most popular flashcard app.
-            </p>
-            <p>Key advantages:</p>
-            <ul class="list-disc list-inside space-y-1 pl-1">
-              <li><strong class="text-foreground">20-30% fewer reviews</strong> for the same retention rate</li>
-              <li><strong class="text-foreground">Optimized defaults</strong> trained on 700M+ real reviews</li>
-              <li><strong class="text-foreground">Better handling of overdue cards</strong> — SM-2 penalized you for reviewing late, FSRS adapts</li>
-              <li><strong class="text-foreground">Open source</strong> — transparent, peer-reviewed, continuously improving</li>
-            </ul>
-          </CardContent>
-        </Card>
+      <!-- How Intervals Grow -->
+      <section class="block">
+        <h2 class="block-title">How intervals grow</h2>
+        <div class="fa-prose">
+          <p>Here's a typical progression for a card rated "Good" each time:</p>
+        </div>
+        <div class="intervals">
+          <template v-for="(step, i) in intervals" :key="step">
+            <span class="interval-step fa-num">{{ step }}</span>
+            <svg class="interval-arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+            <span v-if="i === intervals.length - 1" class="interval-more">…</span>
+          </template>
+        </div>
+        <div class="fa-prose">
+          <p>
+            The intervals grow roughly exponentially. If you rate "Easy", they grow even faster.
+            If you rate "Again", the card resets and works its way back up from short intervals.
+          </p>
+        </div>
+      </section>
 
-        <!-- Sources -->
-        <Card class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-sm">Sources</CardTitle>
-          </CardHeader>
-          <CardContent class="text-sm text-muted-foreground leading-relaxed space-y-2">
-            <ul class="list-disc list-inside space-y-1.5 pl-1">
-              <li><a href="https://en.wikipedia.org/wiki/Spaced_repetition" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">Spaced repetition</a> — Wikipedia</li>
-              <li><a href="https://en.wikipedia.org/wiki/Forgetting_curve" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">Forgetting curve</a> — Wikipedia</li>
-              <li><a href="https://github.com/open-spaced-repetition/fsrs4anki" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">FSRS4Anki</a> — open-source implementation and documentation</li>
-              <li><a href="https://dl.acm.org/doi/10.1145/3534678.3539081" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">A Stochastic Shortest Path Algorithm for Optimizing Spaced Repetition Scheduling</a> — ACM KDD 2022</li>
-              <li><a href="https://doi.org/10.1109/TKDE.2024.3407927" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">Optimizing Spaced Repetition Schedule by Capturing the Dynamics of Memory</a> — IEEE TKDE 2024</li>
-              <li><a href="https://en.wikipedia.org/wiki/SuperMemo#Description_of_SM-2_algorithm" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">SM-2 algorithm</a> — Wikipedia</li>
-            </ul>
-          </CardContent>
-        </Card>
-      </div>
+      <!-- Why FSRS -->
+      <section class="block">
+        <h2 class="block-title">Why FSRS?</h2>
+        <div class="fa-prose">
+          <p>
+            FSRS replaced the <a href="https://en.wikipedia.org/wiki/SuperMemo#Description_of_SM-2_algorithm" target="_blank" rel="noopener noreferrer">SM-2 algorithm</a> (created in 1987) as the standard for spaced repetition.
+            It's now the default in <a href="https://en.wikipedia.org/wiki/Anki_(software)" target="_blank" rel="noopener noreferrer">Anki</a> (since version 23.10), the most popular flashcard app.
+          </p>
+          <p>Key advantages:</p>
+          <ul>
+            <li><strong>20-30% fewer reviews</strong> for the same retention rate</li>
+            <li><strong>Optimized defaults</strong> trained on 700M+ real reviews</li>
+            <li><strong>Better handling of overdue cards</strong> — SM-2 penalized you for reviewing late, FSRS adapts</li>
+            <li><strong>Open source</strong> — transparent, peer-reviewed, continuously improving</li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- Sources -->
+      <section class="block">
+        <h2 class="block-title">Sources</h2>
+        <div class="fa-prose">
+          <ul>
+            <li><a href="https://en.wikipedia.org/wiki/Spaced_repetition" target="_blank" rel="noopener noreferrer">Spaced repetition</a> — Wikipedia</li>
+            <li><a href="https://en.wikipedia.org/wiki/Forgetting_curve" target="_blank" rel="noopener noreferrer">Forgetting curve</a> — Wikipedia</li>
+            <li><a href="https://github.com/open-spaced-repetition/fsrs4anki" target="_blank" rel="noopener noreferrer">FSRS4Anki</a> — open-source implementation and documentation</li>
+            <li><a href="https://dl.acm.org/doi/10.1145/3534678.3539081" target="_blank" rel="noopener noreferrer">A Stochastic Shortest Path Algorithm for Optimizing Spaced Repetition Scheduling</a> — ACM KDD 2022</li>
+            <li><a href="https://doi.org/10.1109/TKDE.2024.3407927" target="_blank" rel="noopener noreferrer">Optimizing Spaced Repetition Schedule by Capturing the Dynamics of Memory</a> — IEEE TKDE 2024</li>
+            <li><a href="https://en.wikipedia.org/wiki/SuperMemo#Description_of_SM-2_algorithm" target="_blank" rel="noopener noreferrer">SM-2 algorithm</a> — Wikipedia</li>
+          </ul>
+        </div>
+      </section>
     </main>
 
     <AppFooter />
   </div>
 </template>
+
+<style scoped>
+.algo-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--paper-0);
+  color: var(--ink-0);
+}
+
+/* Nav — quiet, hairline underline, no glassy blur tint */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--paper-0);
+  border-bottom: 1px solid var(--rule-1);
+}
+.nav-inner {
+  margin: 0 auto;
+  max-width: 760px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 24px;
+}
+
+/* Content column */
+.main {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 760px;
+  flex: 1;
+  padding: 48px 24px 56px;
+}
+
+.page-head { margin-bottom: 12px; }
+.page-lede {
+  margin: 10px 0 0;
+  color: var(--ink-2);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+/* Each section is air + hairline, not a boxed card */
+.block {
+  padding: 28px 0;
+  border-top: 1px solid var(--rule-1);
+}
+.block-title {
+  margin: 0 0 12px;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink-0);
+}
+
+/* Definition list (S / D / R) */
+.defs {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 4px 0 16px;
+}
+.def dt {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink-0);
+  margin-bottom: 2px;
+}
+.def dd {
+  margin: 0;
+  color: var(--ink-1);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+/* Rating rows — leading status dot, hairline separated, no boxed tiles */
+.ratings {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.ratings li {
+  display: flex;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--rule-1);
+}
+.ratings li:last-child { border-bottom: none; }
+.rating-dot {
+  flex: none;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  margin-top: 6px;
+}
+.rating-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink-0);
+  margin-bottom: 1px;
+}
+.ratings p {
+  margin: 0;
+  color: var(--ink-1);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+/* Interval progression */
+.intervals {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 16px;
+}
+.interval-step {
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 7px;
+  background: var(--paper-2);
+  color: var(--ink-0);
+  font-size: 13px;
+}
+.interval-arrow { color: var(--ink-3); }
+.interval-more { color: var(--ink-2); font-size: 15px; }
+</style>

--- a/fasolt.client/src/views/CardDetailView.vue
+++ b/fasolt.client/src/views/CardDetailView.vue
@@ -191,23 +191,19 @@ function onDeleted() {
 </script>
 
 <template>
-  <div v-if="loading" class="py-12 text-center text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="py-12 text-center text-sm text-ink-2">Loading…</div>
 
   <div v-else-if="card" class="space-y-6">
     <!-- Breadcrumb + deck navigation -->
-    <div class="flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
-      <div class="min-w-0 truncate">
-        <template v-if="deckContext">
-          <RouterLink to="/decks" class="hover:text-foreground transition-colors">Decks</RouterLink>
-          <span class="mx-1.5">/</span>
-          <RouterLink :to="`/decks/${deckContext.id}`" class="hover:text-foreground transition-colors">{{ deckContext.name }}</RouterLink>
-        </template>
-        <template v-else>
-          <RouterLink to="/cards" class="hover:text-foreground transition-colors">Cards</RouterLink>
-        </template>
-        <span class="mx-1.5">/</span>
-        <span class="text-foreground">{{ truncatedFront }}</span>
-      </div>
+    <div class="flex items-center justify-between gap-3 text-[11px] text-ink-2">
+      <RouterLink v-if="deckContext" :to="`/decks/${deckContext.id}`" class="fa-back">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+        {{ deckContext.name }}
+      </RouterLink>
+      <RouterLink v-else to="/cards" class="fa-back">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+        Cards
+      </RouterLink>
       <div
         v-if="deckContext && deckCards && navIndex >= 0 && deckCards.cards.length > 1"
         class="flex shrink-0 items-center gap-1"
@@ -222,7 +218,7 @@ function onDeleted() {
         >
           <ChevronLeft class="size-3.5" />
         </Button>
-        <span class="tabular-nums px-1">{{ navIndex + 1 }} / {{ deckCards.cards.length }}</span>
+        <span class="fa-num px-1">{{ navIndex + 1 }} / {{ deckCards.cards.length }}</span>
         <Button
           variant="ghost"
           size="sm"
@@ -239,7 +235,7 @@ function onDeleted() {
     <!-- Header -->
     <div class="flex items-start justify-between">
       <div class="flex items-center gap-2.5">
-        <h1 class="text-base font-bold tracking-tight">{{ truncatedFront }}</h1>
+        <h1 class="text-base font-semibold tracking-tight text-ink-0">{{ truncatedFront }}</h1>
         <Badge variant="outline" class="text-xs">{{ card.state }}</Badge>
       </div>
       <div class="flex items-center gap-2">
@@ -268,123 +264,123 @@ function onDeleted() {
     </div>
 
     <!-- Metadata -->
-    <div class="space-y-1 text-sm text-muted-foreground">
+    <div class="space-y-1 text-sm text-ink-1">
       <div v-if="card.sourceFile" class="flex flex-wrap gap-x-6">
-        <span>Source: <span class="text-foreground">{{ card.sourceFile }}</span></span>
+        <span>Source: <span class="text-ink-0">{{ card.sourceFile }}</span></span>
       </div>
       <div v-if="card.decks.length > 0">
         Decks:
         <template v-for="(d, i) in card.decks" :key="d.id">
-          <RouterLink :to="`/decks/${d.id}`" class="text-foreground hover:text-accent transition-colors">{{ d.name }}</RouterLink><span v-if="i < card.decks.length - 1">, </span>
+          <RouterLink :to="`/decks/${d.id}`" class="text-accent-text hover:underline transition-colors">{{ d.name }}</RouterLink><span v-if="i < card.decks.length - 1">, </span>
         </template>
       </div>
     </div>
 
-    <!-- SRS Stats -->
-    <div class="bg-secondary rounded-lg px-4 py-3 grid grid-cols-4 sm:grid-cols-7 gap-4">
+    <!-- SRS Stats — open row of number + quiet label, one soft surface, no per-tile borders -->
+    <div class="bg-paper-2 rounded-xl px-5 py-4 grid grid-cols-4 sm:grid-cols-7 gap-4">
       <div>
-        <div class="text-[9px] uppercase tracking-widest text-muted-foreground">State</div>
-        <div class="text-sm font-semibold mt-0.5">{{ card.state }}</div>
+        <div class="fa-cap">State</div>
+        <div class="text-sm font-semibold mt-1 text-ink-0">{{ card.state }}</div>
       </div>
       <div>
-        <div class="text-[9px] uppercase tracking-widest text-muted-foreground">Due</div>
-        <div class="text-sm font-semibold mt-0.5">{{ card.dueAt ? formatDate(card.dueAt) : '—' }}</div>
+        <div class="fa-cap">Due</div>
+        <div class="text-sm font-semibold mt-1 text-ink-0">{{ card.dueAt ? formatDate(card.dueAt) : '—' }}</div>
       </div>
       <div>
-        <div class="text-[9px] uppercase tracking-widest text-muted-foreground">Stability</div>
-        <div class="text-sm font-semibold mt-0.5">{{ card.stability != null ? card.stability.toFixed(2) : '—' }}</div>
+        <div class="fa-cap">Stability</div>
+        <div class="text-sm font-semibold mt-1 text-ink-0 fa-num">{{ card.stability != null ? card.stability.toFixed(2) : '—' }}</div>
       </div>
       <div>
-        <div class="text-[9px] uppercase tracking-widest text-muted-foreground">Difficulty</div>
-        <div class="text-sm font-semibold mt-0.5">{{ card.difficulty != null ? card.difficulty.toFixed(2) : '—' }}</div>
+        <div class="fa-cap">Difficulty</div>
+        <div class="text-sm font-semibold mt-1 text-ink-0 fa-num">{{ card.difficulty != null ? card.difficulty.toFixed(2) : '—' }}</div>
       </div>
       <div>
-        <div class="text-[9px] uppercase tracking-widest text-muted-foreground">Step</div>
-        <div class="text-sm font-semibold mt-0.5">{{ card.step ?? '—' }}</div>
+        <div class="fa-cap">Step</div>
+        <div class="text-sm font-semibold mt-1 text-ink-0 fa-num">{{ card.step ?? '—' }}</div>
       </div>
       <div>
-        <div class="text-[9px] uppercase tracking-widest text-muted-foreground">Last Review</div>
-        <div class="text-sm font-semibold mt-0.5">{{ card.lastReviewedAt ? formatDate(card.lastReviewedAt) : '—' }}</div>
+        <div class="fa-cap">Last review</div>
+        <div class="text-sm font-semibold mt-1 text-ink-0">{{ card.lastReviewedAt ? formatDate(card.lastReviewedAt) : '—' }}</div>
       </div>
       <div>
-        <div class="text-[9px] uppercase tracking-widest text-muted-foreground">Created</div>
-        <div class="text-sm font-semibold mt-0.5">{{ formatDate(card.createdAt) }}</div>
+        <div class="fa-cap">Created</div>
+        <div class="text-sm font-semibold mt-1 text-ink-0">{{ formatDate(card.createdAt) }}</div>
       </div>
     </div>
 
-    <div v-if="resetSuccess" class="text-sm text-green-600 dark:text-green-400">Progress reset.</div>
+    <div v-if="resetSuccess" class="text-sm" style="color: var(--c-good)">Progress reset.</div>
 
     <!-- Edit mode -->
     <div v-if="editing" class="space-y-4">
       <div class="space-y-1">
-        <label class="text-[11px] font-medium text-muted-foreground">Source file</label>
+        <label class="fa-cap">Source file</label>
         <Input v-model="editSourceFile" placeholder="e.g. notes.md" class="h-8 text-sm" />
       </div>
       <div class="space-y-1">
-        <label class="text-[11px] font-medium text-muted-foreground">Decks</label>
+        <label class="fa-cap">Decks</label>
         <div class="flex flex-wrap gap-2">
           <label
             v-for="d in decksStore.decks"
             :key="d.id"
-            class="flex items-center gap-1.5 text-sm cursor-pointer"
+            class="flex items-center gap-1.5 text-sm cursor-pointer text-ink-1"
           >
             <input
               type="checkbox"
               :checked="editDeckIds.includes(d.id)"
-              class="rounded border-border"
+              class="rounded border-rule-1 accent-[var(--accent)]"
               @change="editDeckIds.includes(d.id) ? editDeckIds = editDeckIds.filter(id => id !== d.id) : editDeckIds.push(d.id)"
             />
             {{ d.name }}
           </label>
         </div>
       </div>
-      <div class="space-y-1">
-        <div class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground border-b-2 border-border pb-1.5 mb-3">Front (question)</div>
+      <div class="space-y-1.5">
+        <div class="fa-cap border-b border-rule-1 pb-1.5 mb-2">Front (question)</div>
         <textarea
           v-model="front"
-          class="w-full rounded border border-border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          class="w-full rounded-lg border border-rule-1 bg-paper-1 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
           rows="3"
         />
         <details class="mt-2">
-          <summary class="cursor-pointer text-sm text-muted-foreground">SVG (front)</summary>
+          <summary class="cursor-pointer text-sm text-ink-2">SVG (front)</summary>
           <div class="mt-2 grid grid-cols-2 gap-2">
             <textarea
               v-model="editFrontSvg"
-              class="min-h-[100px] rounded border border-border bg-background px-3 py-2 text-sm font-mono"
-              placeholder="Paste SVG markup here..."
+              class="min-h-[100px] rounded-lg border border-rule-1 bg-paper-1 px-3 py-2 text-sm fa-mono"
+              placeholder="Paste SVG markup here…"
             />
-            <div class="flex items-center justify-center rounded border border-border/40 bg-muted/30 p-2 min-h-[100px]">
+            <div class="flex items-center justify-center rounded-lg border border-rule-1 bg-paper-2 p-2 min-h-[100px]">
               <div v-if="editFrontSvg" class="max-h-[200px] w-full [&>svg]:max-h-[200px] [&>svg]:w-full" v-html="sanitizeSvg(editFrontSvg)" />
-              <span v-else class="text-sm text-muted-foreground">Preview</span>
+              <span v-else class="text-sm text-ink-2">Preview</span>
             </div>
           </div>
           <Button v-if="editFrontSvg" variant="ghost" size="sm" class="mt-1 text-sm" @click="editFrontSvg = ''">Clear SVG</Button>
         </details>
       </div>
-      <div class="space-y-1">
-        <div class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground border-b-2 border-border pb-1.5 mb-3">Back (answer)</div>
+      <div class="space-y-1.5">
+        <div class="fa-cap border-b border-rule-1 pb-1.5 mb-2">Back (answer)</div>
         <textarea
           v-model="back"
-          class="w-full rounded border border-border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          class="w-full rounded-lg border border-rule-1 bg-paper-1 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
           rows="8"
         />
         <details class="mt-2">
-          <summary class="cursor-pointer text-sm text-muted-foreground">SVG (back)</summary>
+          <summary class="cursor-pointer text-sm text-ink-2">SVG (back)</summary>
           <div class="mt-2 grid grid-cols-2 gap-2">
             <textarea
               v-model="editBackSvg"
-              class="min-h-[100px] rounded border border-border bg-background px-3 py-2 text-sm font-mono"
-              placeholder="Paste SVG markup here..."
+              class="min-h-[100px] rounded-lg border border-rule-1 bg-paper-1 px-3 py-2 text-sm fa-mono"
+              placeholder="Paste SVG markup here…"
             />
-            <div class="flex items-center justify-center rounded border border-border/40 bg-muted/30 p-2 min-h-[100px]">
+            <div class="flex items-center justify-center rounded-lg border border-rule-1 bg-paper-2 p-2 min-h-[100px]">
               <div v-if="editBackSvg" class="max-h-[200px] w-full [&>svg]:max-h-[200px] [&>svg]:w-full" v-html="sanitizeSvg(editBackSvg)" />
-              <span v-else class="text-sm text-muted-foreground">Preview</span>
+              <span v-else class="text-sm text-ink-2">Preview</span>
             </div>
           </div>
           <Button v-if="editBackSvg" variant="ghost" size="sm" class="mt-1 text-sm" @click="editBackSvg = ''">Clear SVG</Button>
         </details>
       </div>
-      <div v-if="error" class="text-sm text-destructive">{{ error }}</div>
+      <div v-if="error" class="text-sm" style="color: var(--c-again)">{{ error }}</div>
       <div class="flex gap-2">
         <Button size="sm" class="text-sm" :disabled="saving" @click="save">
           {{ saving ? 'Saving...' : 'Save' }}
@@ -394,20 +390,20 @@ function onDeleted() {
     </div>
 
     <!-- View mode -->
-    <div v-else class="space-y-5">
+    <div v-else class="space-y-6">
       <div>
-        <div class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground border-b-2 border-border pb-1.5 mb-3">Front</div>
-        <div v-if="card.frontSvg" class="mb-3 flex justify-center rounded border border-border/40 bg-muted/30 p-4">
+        <div class="fa-cap border-b border-rule-1 pb-1.5 mb-3">Front</div>
+        <div v-if="card.frontSvg" class="mb-3 flex justify-center rounded-lg bg-paper-2 p-4">
           <div class="max-h-[300px] w-full [&>svg]:max-h-[300px] [&>svg]:w-full" v-html="sanitizeSvg(card.frontSvg)" />
         </div>
-        <div class="prose dark:prose-invert max-w-none rounded border border-border/60 px-5 py-4" v-html="render(card.front)" />
+        <div class="fa-prose max-w-none" v-html="render(card.front)" />
       </div>
       <div>
-        <div class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground border-b-2 border-border pb-1.5 mb-3">Back</div>
-        <div v-if="card.backSvg" class="mb-3 flex justify-center rounded border border-border/40 bg-muted/30 p-4">
+        <div class="fa-cap border-b border-rule-1 pb-1.5 mb-3">Back</div>
+        <div v-if="card.backSvg" class="mb-3 flex justify-center rounded-lg bg-paper-2 p-4">
           <div class="max-h-[300px] w-full [&>svg]:max-h-[300px] [&>svg]:w-full" v-html="sanitizeSvg(card.backSvg)" />
         </div>
-        <div class="prose dark:prose-invert max-w-none rounded border border-border/60 px-5 py-4" v-html="render(card.back)" />
+        <div class="fa-prose max-w-none" v-html="render(card.back)" />
       </div>
     </div>
 

--- a/fasolt.client/src/views/CardsView.vue
+++ b/fasolt.client/src/views/CardsView.vue
@@ -151,7 +151,7 @@ async function onDeckMembershipChanged() {
     <header class="cards-head">
       <div class="cards-title">
         <h1 class="page-title">Cards</h1>
-        <span class="fa-mono cards-summary">
+        <span class="cards-summary">
           {{ totalCards.toLocaleString() }} total ·
           {{ stateCounts.review }} review ·
           {{ stateCounts.learning + stateCounts.relearning }} learning ·
@@ -235,10 +235,10 @@ async function onDeckMembershipChanged() {
 
     <!-- Result count + sort -->
     <div v-else class="result-row">
-      <span class="fa-mono">
+      <span>
         Showing {{ filteredCards.length.toLocaleString() }} of {{ totalCards.toLocaleString() }}
       </span>
-      <span class="fa-mono result-hint">Select rows to suspend, change decks, or delete in bulk</span>
+      <span class="result-hint">Select rows to suspend, change decks, or delete in bulk</span>
     </div>
 
     <CardTable
@@ -371,8 +371,8 @@ async function onDeckMembershipChanged() {
   border-color: var(--accent);
   background: var(--accent-soft);
 }
-.filter-pill.is-active .pill-label { color: var(--accent); }
-.filter-pill.is-active .pill-value { color: var(--accent-hi); }
+.filter-pill.is-active .pill-label { color: var(--accent-text); }
+.filter-pill.is-active .pill-value { color: var(--ink-0); }
 .pill-label { font-size: 9px; color: var(--ink-2); }
 .pill-value { color: var(--ink-0); }
 .pill-select {

--- a/fasolt.client/src/views/DeckDetailView.vue
+++ b/fasolt.client/src/views/DeckDetailView.vue
@@ -178,82 +178,79 @@ const stateCounts = computed(() => {
 </script>
 
 <template>
-  <div v-if="loading" class="py-12 text-center text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="loading-state">Loading…</div>
 
-  <div v-else-if="deck" class="space-y-6">
-    <!-- Breadcrumb -->
-    <div class="text-[11px] text-muted-foreground">
-      <RouterLink to="/decks" class="hover:text-foreground transition-colors">Decks</RouterLink>
-      <span class="mx-1.5">/</span>
-      <span class="text-foreground">{{ deck.name }}</span>
-    </div>
+  <div v-else-if="deck" class="deck-page">
+    <RouterLink to="/decks" class="fa-back">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+      Decks
+    </RouterLink>
 
     <!-- Header -->
-    <div class="flex items-start justify-between">
-      <div>
-        <h1 class="text-xl font-bold tracking-tight">{{ deck.name }}</h1>
-        <p v-if="deck.description" class="text-sm text-muted-foreground mt-1">{{ deck.description }}</p>
+    <header class="deck-header">
+      <div class="deck-header-text">
+        <h1 class="page-title">{{ deck.name }}</h1>
+        <p v-if="deck.description" class="deck-description">{{ deck.description }}</p>
       </div>
-      <div class="flex items-center gap-2">
-        <Button
+      <div class="deck-actions">
+        <button
           v-if="deck.dueCount > 0 && !deck.isSuspended"
-          size="sm"
-          class="text-sm"
+          class="fa-btn fa-btn-primary"
           @click="router.push(`/review?deckId=${deck.id}`)"
         >
           Study this deck
-        </Button>
-        <Button
+        </button>
+        <button
           v-if="deck.cardCount > 0 && !deck.isSuspended"
-          variant="outline"
-          size="sm"
-          class="text-sm"
+          class="fa-btn"
           data-testid="custom-study-button"
           @click="router.push(`/review?deckId=${deck.id}&mode=cram`)"
         >
           Custom study
-        </Button>
-        <Button variant="outline" size="sm" class="text-sm" @click="router.push(`/decks/${deck.id}/snapshots`)">
-          <History class="h-3.5 w-3.5 mr-1" />Snapshots
-        </Button>
-        <Button variant="outline" size="sm" class="text-sm" @click="toggleSuspended">
+        </button>
+        <button class="fa-btn" @click="router.push(`/decks/${deck.id}/snapshots`)">
+          <History class="h-3.5 w-3.5" />Snapshots
+        </button>
+        <button class="fa-btn" @click="toggleSuspended">
           {{ deck.isSuspended ? 'Unsuspend' : 'Suspend' }}
-        </Button>
-        <Button variant="outline" size="sm" class="h-7 text-xs" @click="copyDeckId">
+        </button>
+        <button class="fa-btn" @click="copyDeckId">
           {{ idCopied ? 'Copied!' : 'Copy ID' }}
-        </Button>
-        <Button variant="outline" size="sm" class="h-7 text-xs" @click="openEdit">Edit</Button>
-        <Button variant="outline" size="sm" class="h-7 text-xs text-destructive hover:text-destructive" @click="openDelete">Delete</Button>
+        </button>
+        <button class="fa-btn" @click="openEdit">Edit</button>
+        <button class="fa-btn delete-btn" @click="openDelete">Delete</button>
       </div>
-    </div>
+    </header>
 
     <!-- Inactive banner -->
-    <div v-if="deck.isSuspended" class="rounded-md border border-muted bg-muted/50 px-4 py-2 text-sm text-muted-foreground">
+    <div v-if="deck.isSuspended" class="suspended-banner">
       This deck is suspended. Cards are excluded from study.
     </div>
 
-    <!-- Stat bar -->
-    <div class="bg-secondary rounded-lg px-4 py-3 flex items-center gap-5">
-      <div>
-        <span class="text-lg font-bold">{{ deck.cardCount }}</span>
-        <span class="text-sm text-muted-foreground ml-1.5">cards</span>
-      </div>
-      <div class="w-px h-5 bg-border" />
-      <div>
-        <span class="text-lg font-bold text-warning">{{ deck.dueCount }}</span>
-        <span class="text-sm text-muted-foreground ml-1.5">due</span>
-      </div>
-      <div class="w-px h-5 bg-border" />
-      <div class="flex items-center gap-3 text-sm text-muted-foreground">
+    <!-- Stat line — quiet whitespace, no boxed tile -->
+    <div class="stat-line">
+      <span class="stat">
+        <span class="stat-num fa-num">{{ deck.cardCount }}</span>
+        <span class="stat-label">cards</span>
+      </span>
+      <span class="stat-sep">·</span>
+      <span class="stat">
+        <span class="stat-num fa-num" :class="{ 'is-due': deck.dueCount > 0 }">{{ deck.dueCount }}</span>
+        <span class="stat-label">due</span>
+      </span>
+      <span class="stat-sep">·</span>
+      <span class="stat-states">
         <span v-for="state in ['new', 'learning', 'review', 'relearning']" :key="state">
-          {{ stateCounts[state] || 0 }} {{ state }}
+          <span class="fa-num">{{ stateCounts[state] || 0 }}</span> {{ state }}
         </span>
-      </div>
+      </span>
     </div>
 
+    <div class="fa-rule" />
+
     <!-- Cards section -->
-    <div class="space-y-3">
-      <div class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground border-b-2 border-border pb-1.5">Cards in this deck</div>
+    <div class="cards-section">
+      <div class="fa-cap section-label">Cards in this deck</div>
 
       <BulkActionBar
         v-if="selectedCount > 0"
@@ -270,7 +267,7 @@ const stateCounts = computed(() => {
         @clear="selectedIds = []"
       />
 
-      <div v-if="bulkError" class="text-sm text-destructive">{{ bulkError }}</div>
+      <div v-if="bulkError" class="bulk-error">{{ bulkError }}</div>
 
       <CardTable
         v-if="deck.cards.length > 0"
@@ -282,7 +279,7 @@ const stateCounts = computed(() => {
         <template #empty>No cards in this deck yet.</template>
       </CardTable>
 
-      <div v-else class="py-12 text-center text-sm text-muted-foreground">
+      <div v-else class="cards-empty">
         No cards in this deck yet. Add cards from the Cards view.
       </div>
     </div>
@@ -318,7 +315,7 @@ const stateCounts = computed(() => {
             Also delete all {{ deck.cardCount }} cards in this deck
           </label>
         </div>
-        <div v-if="deleteError" class="text-sm text-destructive">{{ deleteError }}</div>
+        <div v-if="deleteError" class="bulk-error">{{ deleteError }}</div>
         <DialogFooter class="gap-2">
           <Button variant="outline" size="sm" @click="deleteOpen = false">Cancel</Button>
           <Button variant="destructive" size="sm" @click="handleDelete">Delete</Button>
@@ -352,3 +349,91 @@ const stateCounts = computed(() => {
     </Dialog>
   </div>
 </template>
+
+<style scoped>
+.deck-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.loading-state {
+  padding: 48px 0;
+  text-align: center;
+  font-size: 14px;
+  color: var(--ink-2);
+}
+
+/* Header */
+.deck-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.deck-header-text { min-width: 0; }
+.deck-page .page-title { font-size: 26px; }
+.deck-description {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: var(--ink-1);
+}
+.deck-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.delete-btn { color: var(--c-again); }
+.delete-btn:hover { color: var(--c-again); border-color: var(--c-again); }
+
+/* Suspended banner — quiet surface, hairline, no glow */
+.suspended-banner {
+  border: 1px solid var(--rule-1);
+  background: var(--paper-2);
+  border-radius: 9px;
+  padding: 10px 14px;
+  font-size: 13.5px;
+  color: var(--ink-1);
+}
+
+/* Stat line — open row of numbers + labels, accent only on "due" */
+.stat-line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--ink-2);
+}
+.stat { display: inline-flex; align-items: baseline; gap: 5px; }
+.stat-num { font-size: 17px; color: var(--ink-0); font-weight: 600; }
+.stat-num.is-due { color: var(--accent-text); }
+.stat-label { color: var(--ink-2); }
+.stat-sep { color: var(--ink-3); }
+.stat-states {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 12px;
+  color: var(--ink-2);
+}
+.stat-states .fa-num { color: var(--ink-1); font-weight: 600; }
+
+/* Cards section */
+.cards-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.section-label { margin-bottom: 2px; }
+
+.bulk-error { font-size: 13px; color: var(--c-again); }
+
+.cards-empty {
+  padding: 48px 0;
+  text-align: center;
+  font-size: 13.5px;
+  color: var(--ink-2);
+}
+</style>

--- a/fasolt.client/src/views/DeckSnapshotsView.vue
+++ b/fasolt.client/src/views/DeckSnapshotsView.vue
@@ -4,7 +4,6 @@ import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { useSnapshotsStore } from '@/stores/snapshots'
 import { useDecksStore } from '@/stores/decks'
 import type { DeckDetail } from '@/types'
-import { Button } from '@/components/ui/button'
 
 const route = useRoute()
 const router = useRouter()
@@ -44,69 +43,125 @@ function formatDate(iso: string) {
 </script>
 
 <template>
-  <div v-if="loading" class="py-12 text-center text-xs text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="loading">Loading…</div>
 
-  <div v-else class="space-y-6">
-    <!-- Breadcrumb -->
-    <div class="text-[11px] text-muted-foreground">
-      <RouterLink to="/decks" class="hover:text-foreground transition-colors">Decks</RouterLink>
-      <span class="mx-1.5">/</span>
-      <RouterLink :to="`/decks/${deckId}`" class="hover:text-foreground transition-colors">{{ deck?.name }}</RouterLink>
-      <span class="mx-1.5">/</span>
-      <span class="text-foreground">Snapshots</span>
-    </div>
+  <div v-else class="snapshots-page">
+    <RouterLink :to="`/decks/${deckId}`" class="fa-back">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+      {{ deck?.name || 'Deck' }}
+    </RouterLink>
 
     <!-- Header -->
-    <div class="flex items-start justify-between">
+    <header class="page-head">
       <div>
-        <h1 class="text-xl font-bold tracking-tight">Snapshots</h1>
-        <p class="text-sm text-muted-foreground mt-1">Restore {{ deck?.name }} to a previous state</p>
+        <h1 class="page-title">Snapshots</h1>
+        <p class="page-sub">Restore {{ deck?.name }} to a previous state</p>
       </div>
-      <Button variant="outline" size="sm" class="text-xs" @click="router.push(`/decks/${deckId}`)">
-        Back to deck
-      </Button>
-    </div>
+      <button class="fa-btn" @click="router.push(`/decks/${deckId}`)">Back to deck</button>
+    </header>
 
     <!-- Snapshots list -->
-    <div v-if="snapshotsStore.snapshots.length > 0" class="flex flex-col gap-2">
+    <div v-if="snapshotsStore.snapshots.length > 0" class="snap-list">
       <div
         v-for="snapshot in snapshotsStore.snapshots"
         :key="snapshot.id"
-        class="flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3"
+        class="snap-row"
       >
-        <div>
-          <div class="text-[13px] font-semibold">{{ formatDate(snapshot.createdAt) }}</div>
-          <div class="text-[11px] text-muted-foreground">
+        <div class="snap-text">
+          <div class="snap-date fa-mono fa-num">{{ formatDate(snapshot.createdAt) }}</div>
+          <div class="snap-meta">
             {{ snapshot.cardCount }} cards
-            <span class="mx-1">·</span>
-            <span v-if="snapshot.contentChanges === 0" class="text-muted-foreground">no content differences</span>
-            <span v-else-if="snapshot.contentChanges != null" class="text-amber-500">{{ snapshot.contentChanges }} content difference{{ snapshot.contentChanges !== 1 ? 's' : '' }}</span>
+            <span class="snap-dot">·</span>
+            <span v-if="snapshot.contentChanges === 0">no content differences</span>
+            <span v-else-if="snapshot.contentChanges != null" class="snap-changes">{{ snapshot.contentChanges }} content difference{{ snapshot.contentChanges !== 1 ? 's' : '' }}</span>
           </div>
         </div>
-        <div class="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            class="text-xs"
+        <div class="snap-actions">
+          <button
+            class="fa-btn"
             @click="router.push(`/decks/${deckId}/snapshots/${snapshot.id}/restore`)"
           >
             Restore
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            class="text-xs text-muted-foreground hover:text-destructive"
+          </button>
+          <button
+            class="fa-btn fa-btn-ghost snap-delete"
             @click="handleDelete(snapshot.id)"
           >
             Delete
-          </Button>
+          </button>
         </div>
       </div>
     </div>
 
     <!-- Empty state -->
-    <div v-else class="py-12 text-center text-xs text-muted-foreground">
+    <div v-else class="empty">
       No snapshots yet. Create one in Settings.
     </div>
   </div>
 </template>
+
+<style scoped>
+.snapshots-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.loading {
+  padding: 48px 0;
+  text-align: center;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+
+
+/* Header */
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.page-head .page-title { font-size: 22px; }
+.page-sub {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--ink-2);
+}
+
+/* Snapshot list — hairline rows, no boxed cards */
+.snap-list { display: flex; flex-direction: column; }
+.snap-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 4px;
+  border-bottom: 1px solid var(--rule-1);
+}
+.snap-row:last-child { border-bottom: none; }
+.snap-text { min-width: 0; }
+.snap-date {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-0);
+}
+.snap-meta {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--ink-2);
+}
+.snap-dot { margin: 0 5px; color: var(--ink-3); }
+.snap-changes { color: var(--accent-text); }
+.snap-actions { display: flex; gap: 8px; flex: none; }
+.snap-delete { color: var(--ink-2); }
+.snap-delete:hover { color: var(--c-again); }
+
+/* Empty state */
+.empty {
+  padding: 48px 0;
+  text-align: center;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+</style>

--- a/fasolt.client/src/views/DecksView.vue
+++ b/fasolt.client/src/views/DecksView.vue
@@ -84,6 +84,13 @@ async function createDeck() {
 
 function startReview(id: string) { router.push(`/review?deckId=${id}`) }
 function startCustomStudy(id: string) { router.push(`/review?deckId=${id}&mode=cram`) }
+
+// Things-style progress ring: how much of a deck is due. r=16 → circumference ≈ 100.53.
+const RING_C = 100.53
+function ringDash(deck: { cardCount: number; dueCount: number }): string {
+  const pct = deck.cardCount ? Math.min(1, deck.dueCount / deck.cardCount) : 0
+  return `${(pct * RING_C).toFixed(1)} ${RING_C}`
+}
 </script>
 
 <template>
@@ -173,42 +180,48 @@ function startCustomStudy(id: string) { router.push(`/review?deckId=${id}&mode=c
 
     <div v-if="decks.loading" class="empty">Loading decks…</div>
 
-    <div v-else class="deck-grid">
-      <article
+    <div v-else-if="decks.decks.length === 0" class="empty">
+      No decks yet. Create one to organize your cards.
+    </div>
+
+    <div v-else class="deck-list">
+      <div
         v-for="deck in sortedDecks"
         :key="deck.id"
-        class="deck-card"
+        class="deck-row"
         :class="{ 'is-suspended': deck.isSuspended }"
       >
-        <span class="deck-stripe" :style="{ background: deckColor(deck.id) }" aria-hidden="true" />
-        <header class="deck-card-head">
-          <div class="deck-card-title">
-            <span class="fa-tag" :style="{ background: deckColor(deck.id) }" aria-hidden="true" />
-            <h3>
-              <RouterLink :to="`/decks/${deck.id}`" class="deck-card-link">{{ deck.name }}</RouterLink>
-            </h3>
-          </div>
-          <span v-if="deck.isSuspended" class="paused-chip fa-cap">paused</span>
-        </header>
-        <p class="deck-card-desc">
-          {{ deck.description || 'No description yet — ask your AI to add one.' }}
-        </p>
-        <footer class="deck-card-foot">
-          <div class="deck-card-counts">
-            <div class="count-block">
-              <span class="fa-mono count-num">{{ deck.cardCount }}</span>
-              <span class="fa-cap count-label">cards</span>
+        <RouterLink :to="`/decks/${deck.id}`" class="deck-row-main" :aria-label="`Open ${deck.name}`">
+          <svg
+            v-if="!deck.isSuspended && deck.cardCount > 0"
+            class="deck-ring" width="22" height="22" viewBox="0 0 36 36" aria-hidden="true"
+          >
+            <circle cx="18" cy="18" r="16" fill="none" stroke="var(--rule-1)" stroke-width="3" />
+            <circle cx="18" cy="18" r="16" fill="none" stroke="var(--accent)" stroke-width="3" stroke-linecap="round" :stroke-dasharray="ringDash(deck)" transform="rotate(-90 18 18)" />
+          </svg>
+          <span v-else class="deck-ring-spacer" aria-hidden="true" />
+          <span class="fa-tag" :style="{ background: deckColor(deck.id) }" aria-hidden="true" />
+          <div class="deck-row-text">
+            <div class="deck-row-name-line">
+              <span class="deck-row-name">{{ deck.name }}</span>
+              <span v-if="deck.isSuspended" class="paused-chip">Paused</span>
             </div>
-            <div class="count-block">
-              <span class="fa-mono count-num" :class="{ 'is-due': deck.dueCount > 0 }">{{ deck.dueCount }}</span>
-              <span class="fa-cap count-label">due</span>
+            <div class="deck-row-sub">
+              {{ deck.description || `${deck.cardCount} ${deck.cardCount === 1 ? 'card' : 'cards'}` }}
             </div>
           </div>
-          <div v-if="!deck.isSuspended && deck.cardCount > 0" class="deck-card-actions">
+        </RouterLink>
+
+        <div class="deck-row-trail">
+          <span v-if="deck.dueCount > 0 && !deck.isSuspended" class="deck-row-due">{{ deck.dueCount }} due</span>
+          <span v-else-if="deck.isSuspended" class="deck-row-meta">{{ deck.cardCount }} cards</span>
+          <span v-else class="deck-row-meta">All caught up</span>
+
+          <div v-if="!deck.isSuspended && deck.cardCount > 0" class="deck-row-actions">
             <button
               v-if="deck.dueCount > 0"
               type="button"
-              class="fa-btn fa-btn-accent deck-card-cta"
+              class="fa-btn fa-btn-accent deck-row-cta"
               :aria-label="`Review ${deck.name}`"
               @click="startReview(deck.id)"
             >
@@ -217,30 +230,29 @@ function startCustomStudy(id: string) { router.push(`/review?deckId=${id}&mode=c
             </button>
             <button
               type="button"
-              class="deck-card-cram"
+              class="deck-row-cram"
               :aria-label="`Custom study for ${deck.name}`"
               @click="startCustomStudy(deck.id)"
             >
               Custom
             </button>
           </div>
-          <span v-else class="fa-cap deck-card-status">
-            {{ deck.isSuspended ? 'resume' : 'empty' }}
-          </span>
-        </footer>
-      </article>
 
-      <button type="button" class="new-deck-card fa-stripe-bg" @click="dialogOpen = true">
-        <div class="plus-tile">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+          <RouterLink :to="`/decks/${deck.id}`" class="deck-chevron-link" tabindex="-1" aria-hidden="true">
+            <svg class="deck-chevron" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 6 6 6-6 6"/></svg>
+          </RouterLink>
         </div>
-        <div class="new-deck-label">New deck</div>
-        <div class="new-deck-hint">or ask your AI: "make a deck from notes/biology.md"</div>
-      </button>
-    </div>
+      </div>
 
-    <div v-if="!decks.loading && decks.decks.length === 0" class="empty">
-      No decks yet. Create one to organize your cards.
+      <button type="button" class="new-deck-row" @click="dialogOpen = true">
+        <span class="plus-tile">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+        </span>
+        <span class="new-deck-text">
+          <span class="new-deck-label">New deck</span>
+          <span class="new-deck-hint">or ask your AI: "make a deck from notes/biology.md"</span>
+        </span>
+      </button>
     </div>
   </div>
 </template>
@@ -267,204 +279,157 @@ function startCustomStudy(id: string) { router.push(`/review?deckId=${id}&mode=c
 }
 .meta-text { font-size: 13px; color: var(--ink-1); }
 .meta-text strong { color: var(--ink-0); font-weight: 600; }
-.meta-mcp {
+
+/* Deck list — rows on the page, hairline separators, no outer box */
+.deck-list { display: flex; flex-direction: column; }
+
+.deck-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 11.5px;
-  color: var(--ink-2);
+  gap: 12px;
+  border-bottom: 1px solid var(--rule-1);
+  transition: background .12s;
 }
+.deck-row:hover { background: var(--paper-2); }
+.deck-row.is-suspended { opacity: 0.65; }
 
-.deck-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+.deck-row-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
   gap: 14px;
-}
-@media (max-width: 1000px) { .deck-grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 640px) { .deck-grid { grid-template-columns: 1fr; } }
-
-.deck-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-height: 196px;
-  padding: 16px 18px 14px;
-  border: 1px solid var(--rule-1);
-  border-radius: 12px;
-  background: var(--paper-1);
-  text-align: left;
-  font: inherit;
+  padding: 15px 4px;
+  text-decoration: none;
   color: inherit;
-  transition: border-color .12s, transform .08s, box-shadow .12s;
+  border-radius: 8px;
+  outline: none;
 }
-.deck-card:has(.deck-card-link:hover),
-.deck-card:has(.deck-card-link:focus-visible) {
-  border-color: var(--ink-3);
-  transform: translateY(-1px);
-  box-shadow: var(--sh-2);
-}
-.deck-card.is-suspended { opacity: 0.7; }
+.deck-row-main:focus-visible { box-shadow: 0 0 0 2px var(--accent); }
+.deck-ring { flex: none; }
+.deck-ring-spacer { width: 22px; height: 22px; flex: none; }
 
-.deck-stripe {
-  position: absolute;
-  top: 0;
-  left: 16px;
-  right: 16px;
-  height: 3px;
-  border-radius: 0 0 2px 2px;
-}
-
-.deck-card-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 10px;
-  margin-top: 6px;
-}
-.deck-card-title {
+.deck-row-text { flex: 1; min-width: 0; }
+.deck-row-name-line {
   display: flex;
   align-items: center;
   gap: 8px;
   min-width: 0;
 }
-.deck-card-title h3 {
-  font-size: 15px;
-  font-weight: 600;
+.deck-row-name {
+  font-size: 15.5px;
   color: var(--ink-0);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin: 0;
-}
-.deck-card-link {
-  color: inherit;
-  text-decoration: none;
-  outline: none;
-}
-.deck-card-link::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: 12px;
-  z-index: 0;
-  cursor: pointer;
-}
-.deck-card-link:focus-visible::after {
-  box-shadow: 0 0 0 2px var(--accent);
 }
 .paused-chip {
-  font-size: 9px;
-  color: var(--c-hard);
-  padding: 2px 6px;
-  border: 1px solid var(--c-hard);
-  border-radius: 4px;
+  flex: none;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ink-2);
+  padding: 1px 7px;
+  border: 1px solid var(--rule-1);
+  border-radius: 999px;
 }
-.deck-card-desc {
+.deck-row-sub {
   font-size: 12.5px;
   color: var(--ink-2);
-  line-height: 1.4;
-  min-height: 36px;
-  margin: 0;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.deck-card-foot {
-  margin-top: auto;
+
+.deck-row-trail {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
-  padding-top: 12px;
-  border-top: 1px solid var(--rule-1);
+  padding-right: 2px;
+  flex: none;
 }
-.deck-card-counts {
-  display: flex;
-  gap: 14px;
-  align-items: baseline;
-}
-.count-block {
-  display: flex;
-  align-items: baseline;
-  gap: 4px;
-}
-.count-num {
-  font-size: 18px;
+.deck-row-due {
+  font-size: 14px;
+  color: var(--accent-text);
   font-weight: 600;
-  color: var(--ink-0);
+  white-space: nowrap;
 }
-.count-num.is-due { color: var(--accent); }
-.count-label { font-size: 9px; }
-.deck-card-actions {
+.deck-row-meta {
+  font-size: 13px;
+  color: var(--ink-2);
+  white-space: nowrap;
+}
+.deck-row-actions {
   display: flex;
   align-items: center;
   gap: 6px;
-  position: relative;
-  z-index: 1;
 }
-.deck-card-cta {
-  height: 26px;
-  padding: 0 10px;
-  font-size: 11.5px;
+.deck-row-cta {
+  height: 28px;
+  padding: 0 11px;
+  font-size: 12px;
 }
-.deck-card-cram {
-  height: 26px;
+.deck-row-cram {
+  height: 28px;
   padding: 0 10px;
-  border-radius: 6px;
+  border-radius: 7px;
   border: 1px solid transparent;
   background: transparent;
   color: var(--ink-2);
   font: inherit;
-  font-size: 11.5px;
+  font-size: 12px;
   font-weight: 500;
   cursor: pointer;
   transition: color .12s, background .12s, border-color .12s;
 }
-.deck-card-cram:hover {
+.deck-row-cram:hover {
   color: var(--ink-0);
   background: var(--paper-2);
   border-color: var(--rule-1);
 }
-.deck-card-status {
-  font-size: 9px;
-  color: var(--ink-2);
+.deck-chevron-link {
+  display: inline-flex;
+  color: var(--ink-3);
 }
+.deck-chevron { flex: none; }
 
-.new-deck-card {
+/* New deck — quiet row, no dashed box / accent hover */
+.new-deck-row {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 10px;
-  min-height: 196px;
-  border: 1px dashed var(--rule-1);
-  border-radius: 12px;
-  color: var(--ink-2);
-  background-color: transparent;
+  gap: 14px;
+  padding: 15px 4px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
   cursor: pointer;
-  transition: border-color .12s, color .12s;
+  color: var(--ink-1);
   font: inherit;
-}
-.new-deck-card:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-.plus-tile {
-  width: 36px;
-  height: 36px;
   border-radius: 8px;
-  border: 1px solid currentColor;
+  transition: background .12s;
+}
+.new-deck-row:hover { background: var(--paper-2); }
+.plus-tile {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  border-radius: 6px;
+  border: 1px solid var(--rule-1);
+  color: var(--ink-2);
   display: grid;
   place-items: center;
 }
+.new-deck-text { display: flex; flex-direction: column; min-width: 0; }
 .new-deck-label {
-  font-size: 13px;
+  font-size: 14.5px;
   font-weight: 500;
+  color: var(--ink-0);
 }
 .new-deck-hint {
-  font-size: 11px;
-  color: var(--ink-3);
-  text-align: center;
-  max-width: 220px;
-  line-height: 1.4;
+  font-size: 12px;
+  color: var(--ink-2);
+  margin-top: 2px;
 }
 
 .empty {
@@ -472,5 +437,9 @@ function startCustomStudy(id: string) { router.push(`/review?deckId=${id}&mode=c
   text-align: center;
   color: var(--ink-2);
   font-size: 13px;
+}
+
+@media (max-width: 560px) {
+  .deck-row-cram { display: none; }
 }
 </style>

--- a/fasolt.client/src/views/ImpressumView.vue
+++ b/fasolt.client/src/views/ImpressumView.vue
@@ -6,7 +6,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
 
 <template>
   <div class="flex min-h-screen flex-col bg-background text-foreground">
-    <nav class="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-md">
+    <nav class="sticky top-0 z-50 border-b border-rule-1 bg-paper-0">
       <div class="mx-auto flex max-w-3xl items-center px-6 py-4">
         <RouterLink to="/" class="flex items-center">
           <FasoltWordmark :size="32" />
@@ -36,7 +36,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
           <h2 class="text-sm font-semibold text-foreground">Contact</h2>
           <p>
             Email:
-            <a href="mailto:info@fasolt.app" class="text-accent hover:underline">info@fasolt.app</a>
+            <a href="mailto:info@fasolt.app" class="text-accent-text hover:underline">info@fasolt.app</a>
           </p>
           <p>
             For project-related inquiries, you can also use the
@@ -44,7 +44,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
               href="https://github.com/philphilphil/fasolt"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-accent hover:underline"
+              class="text-accent-text hover:underline"
             >
               GitHub repository</a>.
           </p>

--- a/fasolt.client/src/views/LandingView.vue
+++ b/fasolt.client/src/views/LandingView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
-import { Button } from '@/components/ui/button'
 import { Bot, Layers, FileText, Brain, BarChart3, Image, Search, Server } from 'lucide-vue-next'
 import ToolSwitcher from '@/components/ToolSwitcher.vue'
 import FasoltStudyPreview from '@/components/FasoltStudyPreview.vue'
@@ -11,19 +10,17 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
 </script>
 
 <template>
-  <div class="min-h-screen bg-background text-foreground">
-    <!-- Grid background -->
-    <div class="pointer-events-none fixed inset-0 -z-10 bg-grid bg-grid-fade opacity-60" />
+  <div class="min-h-screen bg-paper-0 text-ink-0">
+    <!-- Subtle dotted grid background -->
+    <div class="pointer-events-none fixed inset-0 -z-10 bg-grid bg-grid-fade opacity-50" />
 
     <!-- Nav -->
-    <nav class="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-md">
+    <nav class="sticky top-0 z-50 border-b border-rule-1 bg-paper-0">
       <div class="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
         <FasoltWordmark :size="32" />
         <div class="flex items-center gap-2">
           <ThemeToggle />
-          <a href="/login">
-            <Button variant="ghost" size="sm" class="text-xs">Log in</Button>
-          </a>
+          <a href="/login" class="fa-btn fa-btn-ghost">Log in</a>
         </div>
       </div>
     </nav>
@@ -31,24 +28,20 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
     <!-- Hero -->
     <section class="relative mx-auto max-w-5xl px-6 pt-6 pb-12 sm:pt-10 sm:pb-16">
       <div class="max-w-2xl">
-        <p class="mb-4 text-xs uppercase tracking-[0.2em] text-accent">spaced repetition</p>
-        <h1 class="text-2xl sm:text-4xl font-bold tracking-tight leading-tight mb-5">
+        <p class="fa-cap mb-4 text-accent-text">Spaced repetition</p>
+        <h1 class="page-title text-3xl sm:text-5xl mb-5">
           Spaced repetition,<br class="hidden sm:block" />
-          powered by the <span class="text-accent text-glow">AI you already use</span>.
+          powered by the <span class="text-accent-text">AI you already use</span>.
         </h1>
-        <p class="text-sm text-muted-foreground mb-8 max-w-md leading-relaxed">
+        <p class="text-[15px] text-ink-1 mb-8 max-w-md leading-relaxed">
           Ask ChatGPT, Claude, or Mistral to make flashcards from your notes, a topic, or anything you want to learn.
           Study on the web or the iOS app. Free.
         </p>
         <div class="flex flex-wrap items-center gap-3">
-          <a href="/register">
-            <Button class="glow-accent">Get started</Button>
-          </a>
-          <a href="/login">
-            <Button variant="outline">Log in</Button>
-          </a>
+          <a href="/register" class="fa-btn fa-btn-primary">Get started</a>
+          <a href="/login" class="fa-btn">Log in</a>
         </div>
-        <p class="mt-4 text-xs text-muted-foreground/80">
+        <p class="mt-4 text-xs text-ink-2">
           Works with ChatGPT, Claude, Mistral, and any MCP-compatible AI.
         </p>
       </div>
@@ -58,19 +51,19 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
     <section class="relative mx-auto max-w-6xl px-6 pb-20">
       <div class="grid gap-4 lg:grid-cols-[1fr_auto_1fr] lg:gap-4">
         <div class="flex min-w-0 flex-col">
-          <p class="mb-3 text-[10px] uppercase tracking-[0.2em] text-accent/70">1 — Ask your AI</p>
+          <p class="fa-cap mb-3">1 — Ask your AI</p>
           <ToolSwitcher />
         </div>
-        <div class="hidden lg:flex items-center justify-center text-muted-foreground/60">
+        <div class="hidden lg:flex items-center justify-center text-ink-3">
           <ArrowRight :size="24" />
         </div>
-        <div class="flex justify-center lg:hidden text-muted-foreground/60 -my-1">
+        <div class="flex justify-center lg:hidden text-ink-3 -my-1">
           <ArrowDown :size="18" />
         </div>
         <div class="flex min-w-0 flex-col">
-          <p class="mb-3 text-[10px] uppercase tracking-[0.2em] text-accent/70">2 — Study in fasolt</p>
+          <p class="fa-cap mb-3">2 — Study in fasolt</p>
           <FasoltStudyPreview />
-          <p class="mt-3 text-xs text-muted-foreground">
+          <p class="mt-3 text-xs text-ink-2">
             Cards are scheduled with FSRS — the more you remember, the longer the gaps.
           </p>
         </div>
@@ -78,28 +71,28 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
     </section>
 
     <!-- How it works -->
-    <section class="border-y border-border/60 bg-card/50">
+    <section class="border-y border-rule-1 bg-paper-1">
       <div class="mx-auto max-w-5xl px-6 py-16">
-        <p class="text-xs uppercase tracking-[0.2em] text-accent mb-8">How it works</p>
+        <p class="fa-cap mb-8">How it works</p>
         <div class="grid gap-10 sm:grid-cols-3">
           <div>
-            <span class="text-xs text-accent/60 mb-2 block">01</span>
-            <h3 class="text-sm font-semibold mb-2">Connect your AI</h3>
-            <p class="text-xs text-muted-foreground leading-relaxed">
+            <span class="fa-num text-accent-text mb-2 block text-xs">01</span>
+            <h3 class="text-sm font-semibold mb-2 text-ink-0">Connect your AI</h3>
+            <p class="text-xs text-ink-1 leading-relaxed">
               Add fasolt to ChatGPT, Claude, Mistral, or any AI tool that supports connectors.
             </p>
           </div>
           <div>
-            <span class="text-xs text-accent/60 mb-2 block">02</span>
-            <h3 class="text-sm font-semibold mb-2">Create flashcards</h3>
-            <p class="text-xs text-muted-foreground leading-relaxed">
+            <span class="fa-num text-accent-text mb-2 block text-xs">02</span>
+            <h3 class="text-sm font-semibold mb-2 text-ink-0">Create flashcards</h3>
+            <p class="text-xs text-ink-1 leading-relaxed">
               Ask your agent to make cards from your notes, a topic, or anything you want to learn.
             </p>
           </div>
           <div>
-            <span class="text-xs text-accent/60 mb-2 block">03</span>
-            <h3 class="text-sm font-semibold mb-2">Learn and remember</h3>
-            <p class="text-xs text-muted-foreground leading-relaxed">
+            <span class="fa-num text-accent-text mb-2 block text-xs">03</span>
+            <h3 class="text-sm font-semibold mb-2 text-ink-0">Learn and remember</h3>
+            <p class="text-xs text-ink-1 leading-relaxed">
               Study your cards on the web or the iOS app. Spaced repetition schedules reviews at optimal intervals.
             </p>
           </div>
@@ -109,47 +102,47 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
 
     <!-- Features -->
     <section class="mx-auto max-w-5xl px-6 py-16">
-      <p class="text-xs uppercase tracking-[0.2em] text-accent mb-8">Features</p>
-      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        <div class="rounded border border-border/60 bg-card/50 p-4">
-          <Bot :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">Bring your own AI</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">Use ChatGPT, Claude, Mistral, or any MCP-compatible agent to create and manage cards.</p>
+      <p class="fa-cap mb-8">Features</p>
+      <div class="grid gap-x-10 gap-y-8 sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <Bot :size="18" class="text-accent mb-2" />
+          <h3 class="text-sm font-semibold mb-1 text-ink-0">Bring your own AI</h3>
+          <p class="text-xs text-ink-1 leading-relaxed">Use ChatGPT, Claude, Mistral, or any MCP-compatible agent to create and manage cards.</p>
         </div>
-        <div class="rounded border border-border/60 bg-card/50 p-4">
-          <Brain :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">FSRS scheduling</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">Optimal review intervals backed by research. <RouterLink to="/algorithm" class="text-accent hover:underline">Learn more</RouterLink></p>
+        <div>
+          <Brain :size="18" class="text-accent mb-2" />
+          <h3 class="text-sm font-semibold mb-1 text-ink-0">FSRS scheduling</h3>
+          <p class="text-xs text-ink-1 leading-relaxed">Optimal review intervals backed by research. <RouterLink to="/algorithm" class="text-accent-text hover:underline">Learn more</RouterLink></p>
         </div>
-        <div class="rounded border border-border/60 bg-card/50 p-4">
-          <Layers :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">Decks</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">Organize cards into focused study groups.</p>
+        <div>
+          <Layers :size="18" class="text-accent mb-2" />
+          <h3 class="text-sm font-semibold mb-1 text-ink-0">Decks</h3>
+          <p class="text-xs text-ink-1 leading-relaxed">Organize cards into focused study groups.</p>
         </div>
-        <div class="rounded border border-border/60 bg-card/50 p-4">
-          <FileText :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">Source tracking</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">Cards retain context via file and heading.</p>
+        <div>
+          <FileText :size="18" class="text-accent mb-2" />
+          <h3 class="text-sm font-semibold mb-1 text-ink-0">Source tracking</h3>
+          <p class="text-xs text-ink-1 leading-relaxed">Cards retain context via file and heading.</p>
         </div>
-        <div class="rounded border border-border/60 bg-card/50 p-4">
-          <BarChart3 :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">Dashboard</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">Stats, due counts, and study streaks.</p>
+        <div>
+          <BarChart3 :size="18" class="text-accent mb-2" />
+          <h3 class="text-sm font-semibold mb-1 text-ink-0">Dashboard</h3>
+          <p class="text-xs text-ink-1 leading-relaxed">Stats, due counts, and study streaks.</p>
         </div>
-        <div class="rounded border border-border/60 bg-card/50 p-4">
-          <Image :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">SVG support</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">Diagrams and visualizations on cards.</p>
+        <div>
+          <Image :size="18" class="text-accent mb-2" />
+          <h3 class="text-sm font-semibold mb-1 text-ink-0">SVG support</h3>
+          <p class="text-xs text-ink-1 leading-relaxed">Diagrams and visualizations on cards.</p>
         </div>
-        <div class="rounded border border-border/60 bg-card/50 p-4">
-          <Search :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">Search</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">Full-text search across all your cards.</p>
+        <div>
+          <Search :size="18" class="text-accent mb-2" />
+          <h3 class="text-sm font-semibold mb-1 text-ink-0">Search</h3>
+          <p class="text-xs text-ink-1 leading-relaxed">Full-text search across all your cards.</p>
         </div>
-        <div class="rounded border border-border/60 bg-card/50 p-4">
-          <Server :size="16" class="text-accent mb-2" />
-          <h3 class="text-sm font-semibold mb-1">Self-hostable</h3>
-          <p class="text-xs text-muted-foreground leading-relaxed">Run your own instance with Docker.</p>
+        <div>
+          <Server :size="18" class="text-accent mb-2" />
+          <h3 class="text-sm font-semibold mb-1 text-ink-0">Self-hostable</h3>
+          <p class="text-xs text-ink-1 leading-relaxed">Run your own instance with Docker.</p>
         </div>
       </div>
     </section>
@@ -157,9 +150,9 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
     <!-- iOS showcase -->
     <section class="mx-auto max-w-5xl px-6 py-16">
       <div class="flex flex-col items-center gap-6">
-        <p class="text-xs uppercase tracking-[0.2em] text-accent">Study anywhere</p>
-        <a href="https://apps.apple.com/us/app/fasolt/id6761048313" target="_blank" rel="noopener">
-          <Button variant="outline">Download on the App Store</Button>
+        <p class="fa-cap">Study anywhere</p>
+        <a href="https://apps.apple.com/us/app/fasolt/id6761048313" target="_blank" rel="noopener" class="fa-btn">
+          Download on the App Store
         </a>
         <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
           <img
@@ -188,10 +181,8 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
 
     <!-- CTA -->
     <section class="mx-auto max-w-5xl px-6 py-16 text-center">
-      <p class="text-xs text-muted-foreground mb-4 uppercase tracking-[0.2em]">Free and open source</p>
-      <a href="/register">
-        <Button class="glow-accent">Get started</Button>
-      </a>
+      <p class="fa-cap mb-4">Free and open source</p>
+      <a href="/register" class="fa-btn fa-btn-primary">Get started</a>
     </section>
 
     <AppFooter />

--- a/fasolt.client/src/views/LandingView.vue
+++ b/fasolt.client/src/views/LandingView.vue
@@ -51,7 +51,11 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
     <section class="relative mx-auto max-w-6xl px-6 pb-20">
       <div class="grid gap-4 lg:grid-cols-[1fr_auto_1fr] lg:gap-4">
         <div class="flex min-w-0 flex-col">
-          <p class="fa-cap mb-3">1 — Ask your AI</p>
+          <div class="mb-3">
+            <span class="inline-block rounded-full bg-accent-soft px-2.5 py-0.5 text-[11px] font-semibold text-accent-text">Step 1</span>
+            <h3 class="mt-2 text-base font-semibold text-ink-0">Ask your AI to make cards</h3>
+            <p class="mt-0.5 text-[12.5px] text-ink-2">From your notes, a topic, anything you want to learn.</p>
+          </div>
           <ToolSwitcher />
         </div>
         <div class="hidden lg:flex items-center justify-center text-ink-3">
@@ -61,7 +65,11 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
           <ArrowDown :size="18" />
         </div>
         <div class="flex min-w-0 flex-col">
-          <p class="fa-cap mb-3">2 — Study in fasolt</p>
+          <div class="mb-3">
+            <span class="inline-block rounded-full bg-accent-soft px-2.5 py-0.5 text-[11px] font-semibold text-accent-text">Step 2</span>
+            <h3 class="mt-2 text-base font-semibold text-ink-0">Study them in fasolt</h3>
+            <p class="mt-0.5 text-[12.5px] text-ink-2">On the web or the iOS app.</p>
+          </div>
           <FasoltStudyPreview />
           <p class="mt-3 text-xs text-ink-2">
             Cards are scheduled with FSRS — the more you remember, the longer the gaps.

--- a/fasolt.client/src/views/McpView.vue
+++ b/fasolt.client/src/views/McpView.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { RouterLink } from 'vue-router'
-import { Button } from '@/components/ui/button'
 import { Copy, Check, ChevronDown } from 'lucide-vue-next'
 import { useAuthStore } from '@/stores/auth'
 import AppFooter from '@/components/AppFooter.vue'
@@ -33,32 +32,28 @@ function copyToClipboard(text: string, key: string) {
 
 <template>
   <div :class="auth.isAuthenticated ? '' : 'flex min-h-screen flex-col bg-background text-foreground'">
-    <nav v-if="!auth.isAuthenticated" class="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-md">
+    <nav v-if="!auth.isAuthenticated" class="mcp-nav sticky top-0 z-50 border-b">
       <div class="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
         <RouterLink to="/" class="flex items-center">
           <FasoltWordmark :size="32" />
         </RouterLink>
         <div class="flex items-center gap-2">
           <ThemeToggle />
-          <a href="/login">
-            <Button variant="ghost" size="sm" class="text-sm">Log in</Button>
-          </a>
-          <a href="/register">
-            <Button size="sm" class="text-sm">Sign up</Button>
-          </a>
+          <a href="/login" class="fa-btn fa-btn-ghost">Log in</a>
+          <a href="/register" class="fa-btn fa-btn-primary">Sign up</a>
         </div>
       </div>
     </nav>
 
     <main :class="auth.isAuthenticated ? '' : 'mx-auto w-full max-w-5xl flex-1 px-6 py-12'">
       <div :class="auth.isAuthenticated ? 'mcp-page' : 'flex flex-col gap-6'">
-        <h1 class="page-title">MCP Setup</h1>
+        <h1 class="page-title">MCP setup</h1>
 
-        <p class="text-sm text-muted-foreground leading-relaxed">
+        <p class="mcp-intro">
           Connect your AI agent to create flashcards from your notes. Copy your MCP URL and add it to your client.
         </p>
 
-        <p class="text-sm text-muted-foreground">
+        <p class="mcp-intro">
           You'll be asked to log in when your AI client first connects. Pick your client below to see the steps.
         </p>
 
@@ -69,13 +64,14 @@ function copyToClipboard(text: string, key: string) {
               <ChevronDown class="mcp-client-chevron" :size="16" />
             </summary>
             <div class="mcp-client-body">
-              <div class="relative">
-                <pre class="rounded border border-border bg-secondary px-3 py-2.5 pr-10 text-sm overflow-x-auto whitespace-pre-wrap break-all">{{ remoteClaudeCommand }}</pre>
+              <div class="mcp-code">
+                <pre class="mcp-pre fa-mono whitespace-pre-wrap break-all">{{ remoteClaudeCommand }}</pre>
                 <button
-                  class="absolute right-2 top-2 rounded p-1 text-muted-foreground hover:text-foreground transition-colors"
+                  class="mcp-copy"
+                  aria-label="Copy command"
                   @click="copyToClipboard(remoteClaudeCommand, 'claude')"
                 >
-                  <Check v-if="copiedStates['claude']" class="h-3.5 w-3.5 text-success" />
+                  <Check v-if="copiedStates['claude']" class="h-3.5 w-3.5" :style="{ color: 'var(--c-good)' }" />
                   <Copy v-else class="h-3.5 w-3.5" />
                 </button>
               </div>
@@ -88,25 +84,26 @@ function copyToClipboard(text: string, key: string) {
               <ChevronDown class="mcp-client-chevron" :size="16" />
             </summary>
             <div class="mcp-client-body">
-              <div class="rounded border border-border bg-secondary px-3 py-2.5 text-sm text-muted-foreground">
-                <ol class="list-decimal list-inside space-y-1.5">
-                  <li>Go to <a href="https://claude.ai/customize/connectors" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-2">Customize</a> → <span class="font-medium text-foreground">Connectors</span></li>
-                  <li>Click <span class="font-medium text-foreground">+</span> then <span class="font-medium text-foreground">Add Custom Connector</span></li>
+              <div class="fa-prose mcp-steps">
+                <ol>
+                  <li>Go to <a href="https://claude.ai/customize/connectors" target="_blank" rel="noopener noreferrer">Customize</a> → <strong>Connectors</strong></li>
+                  <li>Click <strong>+</strong> then <strong>Add Custom Connector</strong></li>
                   <li>Paste your MCP URL:
-                    <span class="inline-flex items-center gap-1.5 mt-1">
-                      <code class="rounded border border-border bg-background px-1.5 py-0.5 text-xs">{{ origin }}/mcp</code>
+                    <span class="mcp-inline-url">
+                      <code class="fa-mono">{{ origin }}/mcp</code>
                       <button
-                        class="rounded p-0.5 text-muted-foreground hover:text-foreground transition-colors"
+                        class="mcp-copy mcp-copy-sm"
+                        aria-label="Copy URL"
                         @click="copyToClipboard(`${origin}/mcp`, 'claudeai-url')"
                       >
-                        <Check v-if="copiedStates['claudeai-url']" class="h-3 w-3 text-success" />
+                        <Check v-if="copiedStates['claudeai-url']" class="h-3 w-3" :style="{ color: 'var(--c-good)' }" />
                         <Copy v-else class="h-3 w-3" />
                       </button>
                     </span>
                   </li>
                   <li>Authorize with your fasolt account</li>
                 </ol>
-                <p class="mt-2"><a href="https://support.anthropic.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-2">See documentation</a></p>
+                <p><a href="https://support.anthropic.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp" target="_blank" rel="noopener noreferrer">See documentation</a></p>
               </div>
             </div>
           </details>
@@ -117,25 +114,26 @@ function copyToClipboard(text: string, key: string) {
               <ChevronDown class="mcp-client-chevron" :size="16" />
             </summary>
             <div class="mcp-client-body">
-              <div class="rounded border border-border bg-secondary px-3 py-2.5 text-sm text-muted-foreground">
-                <ol class="list-decimal list-inside space-y-1.5">
-                  <li>Open Le Chat → <span class="font-medium text-foreground">Intelligence</span> → <a href="https://chat.mistral.ai/connections" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-2">Connectors</a></li>
-                  <li>Click <span class="font-medium text-foreground">+ Add Connector</span> → <span class="font-medium text-foreground">Custom MCP Connector</span></li>
-                  <li>Set <span class="font-medium text-foreground">Connector name</span> to <code class="rounded border border-border bg-background px-1 py-0.5 text-xs">fasolt</code> and paste the server URL:
-                    <span class="inline-flex items-center gap-1.5 mt-1">
-                      <code class="rounded border border-border bg-background px-1.5 py-0.5 text-xs">{{ origin }}/mcp</code>
+              <div class="fa-prose mcp-steps">
+                <ol>
+                  <li>Open Le Chat → <strong>Intelligence</strong> → <a href="https://chat.mistral.ai/connections" target="_blank" rel="noopener noreferrer">Connectors</a></li>
+                  <li>Click <strong>+ Add Connector</strong> → <strong>Custom MCP Connector</strong></li>
+                  <li>Set <strong>Connector name</strong> to <code class="fa-mono">fasolt</code> and paste the server URL:
+                    <span class="mcp-inline-url">
+                      <code class="fa-mono">{{ origin }}/mcp</code>
                       <button
-                        class="rounded p-0.5 text-muted-foreground hover:text-foreground transition-colors"
+                        class="mcp-copy mcp-copy-sm"
+                        aria-label="Copy URL"
                         @click="copyToClipboard(`${origin}/mcp`, 'mistral-url')"
                       >
-                        <Check v-if="copiedStates['mistral-url']" class="h-3 w-3 text-success" />
+                        <Check v-if="copiedStates['mistral-url']" class="h-3 w-3" :style="{ color: 'var(--c-good)' }" />
                         <Copy v-else class="h-3 w-3" />
                       </button>
                     </span>
                   </li>
-                  <li>Click <span class="font-medium text-foreground">Connect</span> and authorize with your fasolt account</li>
+                  <li>Click <strong>Connect</strong> and authorize with your fasolt account</li>
                 </ol>
-                <p class="mt-2"><a href="https://docs.mistral.ai/le-chat/knowledge-integrations/connectors/mcp-connectors/" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-2">See documentation</a></p>
+                <p><a href="https://docs.mistral.ai/le-chat/knowledge-integrations/connectors/mcp-connectors/" target="_blank" rel="noopener noreferrer">See documentation</a></p>
               </div>
             </div>
           </details>
@@ -146,26 +144,27 @@ function copyToClipboard(text: string, key: string) {
               <ChevronDown class="mcp-client-chevron" :size="16" />
             </summary>
             <div class="mcp-client-body">
-              <p class="text-sm text-muted-foreground mb-2">Requires Pro, Team, Enterprise, or Edu plan.</p>
-              <div class="rounded border border-border bg-secondary px-3 py-2.5 text-sm text-muted-foreground">
-                <ol class="list-decimal list-inside space-y-1.5">
-                  <li>Enable <span class="font-medium text-foreground">Developer Mode</span> in <span class="font-medium text-foreground">Settings</span> → <span class="font-medium text-foreground">Apps</span> → <span class="font-medium text-foreground">Advanced Settings</span></li>
-                  <li>Click <span class="font-medium text-foreground">Create App</span></li>
+              <p class="mcp-note">Requires Pro, Team, Enterprise, or Edu plan.</p>
+              <div class="fa-prose mcp-steps">
+                <ol>
+                  <li>Enable <strong>Developer Mode</strong> in <strong>Settings</strong> → <strong>Apps</strong> → <strong>Advanced Settings</strong></li>
+                  <li>Click <strong>Create App</strong></li>
                   <li>Paste your MCP URL:
-                    <span class="inline-flex items-center gap-1.5 mt-1">
-                      <code class="rounded border border-border bg-background px-1.5 py-0.5 text-xs">{{ origin }}/mcp</code>
+                    <span class="mcp-inline-url">
+                      <code class="fa-mono">{{ origin }}/mcp</code>
                       <button
-                        class="rounded p-0.5 text-muted-foreground hover:text-foreground transition-colors"
+                        class="mcp-copy mcp-copy-sm"
+                        aria-label="Copy URL"
                         @click="copyToClipboard(`${origin}/mcp`, 'chatgpt-url')"
                       >
-                        <Check v-if="copiedStates['chatgpt-url']" class="h-3 w-3 text-success" />
+                        <Check v-if="copiedStates['chatgpt-url']" class="h-3 w-3" :style="{ color: 'var(--c-good)' }" />
                         <Copy v-else class="h-3 w-3" />
                       </button>
                     </span>
                   </li>
                   <li>Authorize with your fasolt account</li>
                 </ol>
-                <p class="mt-2"><a href="https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-2">See documentation</a></p>
+                <p><a href="https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta" target="_blank" rel="noopener noreferrer">See documentation</a></p>
               </div>
             </div>
           </details>
@@ -176,16 +175,17 @@ function copyToClipboard(text: string, key: string) {
               <ChevronDown class="mcp-client-chevron" :size="16" />
             </summary>
             <div class="mcp-client-body">
-              <p class="text-sm text-muted-foreground mb-2">
-                Add to <code class="rounded border border-border bg-secondary px-1 py-0.5 text-xs">.vscode/mcp.json</code> or <code class="rounded border border-border bg-secondary px-1 py-0.5 text-xs">~/.copilot/mcp-config.json</code>:
+              <p class="mcp-note">
+                Add to <code class="fa-mono mcp-inline-code">.vscode/mcp.json</code> or <code class="fa-mono mcp-inline-code">~/.copilot/mcp-config.json</code>:
               </p>
-              <div class="relative">
-                <pre class="rounded border border-border bg-secondary px-3 py-2.5 pr-10 text-sm overflow-x-auto">{{ remoteCopilotConfig }}</pre>
+              <div class="mcp-code">
+                <pre class="mcp-pre fa-mono">{{ remoteCopilotConfig }}</pre>
                 <button
-                  class="absolute right-2 top-2 rounded p-1 text-muted-foreground hover:text-foreground transition-colors"
+                  class="mcp-copy"
+                  aria-label="Copy config"
                   @click="copyToClipboard(remoteCopilotConfig, 'copilot')"
                 >
-                  <Check v-if="copiedStates['copilot']" class="h-3.5 w-3.5 text-success" />
+                  <Check v-if="copiedStates['copilot']" class="h-3.5 w-3.5" :style="{ color: 'var(--c-good)' }" />
                   <Copy v-else class="h-3.5 w-3.5" />
                 </button>
               </div>
@@ -200,54 +200,122 @@ function copyToClipboard(text: string, key: string) {
 </template>
 
 <style scoped>
+.mcp-nav {
+  background: var(--paper-0);
+}
 .mcp-page {
   padding: 28px 0 40px;
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 18px;
 }
+.mcp-intro {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ink-1);
+  margin: 0;
+  max-width: 60ch;
+}
+
+/* Client list — rows separated by hairlines, no boxed cards */
 .mcp-accordion {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  border-top: 1px solid var(--rule-1);
 }
 .mcp-client {
-  border: 1px solid var(--rule-1);
-  border-radius: 10px;
-  background: var(--paper-1);
-  overflow: hidden;
-  transition: border-color .12s;
-}
-.mcp-client[open] {
-  border-color: var(--ink-3);
+  border-bottom: 1px solid var(--rule-1);
 }
 .mcp-client-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
+  padding: 14px 4px;
   cursor: pointer;
   user-select: none;
   list-style: none;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 500;
   color: var(--ink-0);
-  transition: background .12s;
+  transition: color .12s;
 }
 .mcp-client-head::-webkit-details-marker { display: none; }
-.mcp-client-head:hover { background: var(--paper-2); }
-.mcp-client-name { letter-spacing: -0.005em; }
+.mcp-client-head:hover .mcp-client-name { color: var(--accent-text); }
+.mcp-client-name { letter-spacing: -0.01em; transition: color .12s; }
 .mcp-client-chevron {
-  color: var(--ink-2);
+  color: var(--ink-3);
   transition: transform .15s ease, color .12s;
 }
 .mcp-client[open] .mcp-client-chevron {
   transform: rotate(180deg);
-  color: var(--accent);
+  color: var(--ink-2);
 }
 .mcp-client-body {
-  padding: 0 16px 16px;
-  border-top: 1px solid var(--rule-1);
-  padding-top: 14px;
+  padding: 2px 4px 18px;
+}
+
+/* Step lists (fa-prose handles type; trim trailing margins) */
+.mcp-steps { font-size: 14px; }
+.mcp-steps ol { margin: 0; }
+.mcp-steps li { margin: .3em 0; }
+.mcp-steps p { margin: .8em 0 0; }
+.mcp-note {
+  font-size: 13px;
+  color: var(--ink-2);
+  margin: 0 0 10px;
+}
+
+/* Inline code chip */
+.mcp-inline-code,
+.mcp-inline-url code {
+  font-size: 12.5px;
+  padding: 1px 6px;
+  background: var(--paper-2);
+  border: 1px solid var(--rule-1);
+  border-radius: 5px;
+  color: var(--ink-0);
+}
+.mcp-inline-url {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+/* Code block — quiet sunken surface, system mono, flat copy button */
+.mcp-code {
+  position: relative;
+  margin-top: 4px;
+}
+.mcp-pre {
+  margin: 0;
+  padding: 12px 40px 12px 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-0);
+  background: var(--paper-2);
+  border: 1px solid var(--rule-1);
+  border-radius: 9px;
+  overflow-x: auto;
+}
+.mcp-copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  transition: color .12s, background .12s;
+}
+.mcp-copy:hover { color: var(--ink-0); background: var(--paper-1); }
+.mcp-copy-sm {
+  position: static;
+  padding: 3px;
 }
 </style>

--- a/fasolt.client/src/views/NotFoundView.vue
+++ b/fasolt.client/src/views/NotFoundView.vue
@@ -1,16 +1,13 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
-import { Button } from '@/components/ui/button'
 </script>
 
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-background">
+  <div class="flex min-h-screen items-center justify-center bg-paper-0">
     <div class="text-center">
-      <p class="text-5xl font-bold text-accent/20">404</p>
-      <p class="mt-3 text-xs text-muted-foreground">Page not found</p>
-      <RouterLink to="/dashboard" class="mt-6 inline-block">
-        <Button variant="outline" size="sm" class="text-xs">Back to dashboard</Button>
-      </RouterLink>
+      <p class="fa-num text-5xl font-semibold text-ink-3">404</p>
+      <p class="mt-3 text-xs text-ink-2">Page not found</p>
+      <RouterLink to="/dashboard" class="fa-btn mt-6 inline-flex">Back to dashboard</RouterLink>
     </div>
   </div>
 </template>

--- a/fasolt.client/src/views/PrivacyPolicyView.vue
+++ b/fasolt.client/src/views/PrivacyPolicyView.vue
@@ -6,7 +6,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
 
 <template>
   <div class="min-h-screen bg-background text-foreground">
-    <nav class="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-md">
+    <nav class="sticky top-0 z-50 border-b border-rule-1 bg-paper-0">
       <div class="mx-auto flex max-w-3xl items-center px-6 py-4">
         <RouterLink to="/" class="flex items-center">
           <FasoltWordmark :size="32" />
@@ -28,7 +28,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
           <p>c/o Webix Solutions GmbH</p>
           <p>Zuckerfabrik 14</p>
           <p>70376 Stuttgart, Germany</p>
-          <p>Email: <a href="mailto:info@fasolt.app" class="text-accent hover:underline">info@fasolt.app</a></p>
+          <p>Email: <a href="mailto:info@fasolt.app" class="text-accent-text hover:underline">info@fasolt.app</a></p>
         </address>
       </section>
 
@@ -71,7 +71,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
       <section class="space-y-2">
         <h2 class="text-sm font-semibold text-foreground">6. International Data Transfers</h2>
         <p>Some of the providers listed above may process personal data outside the EU or EEA, including in the United States. Where this happens, we rely on an adequacy decision, Standard Contractual Clauses, or other lawful transfer mechanism required by applicable law, together with supplementary safeguards where necessary.</p>
-        <p>You can contact us at <a href="mailto:info@fasolt.app" class="text-accent hover:underline">info@fasolt.app</a> if you would like more information about the transfer safeguards relevant to a particular processing activity.</p>
+        <p>You can contact us at <a href="mailto:info@fasolt.app" class="text-accent-text hover:underline">info@fasolt.app</a> if you would like more information about the transfer safeguards relevant to a particular processing activity.</p>
       </section>
 
       <section class="space-y-2">
@@ -98,9 +98,9 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
           <li><strong class="text-foreground">Data portability</strong> — receive your data in a structured, machine-readable format (Art. 20 GDPR)</li>
           <li><strong class="text-foreground">Object</strong> to processing based on legitimate interest (Art. 21 GDPR)</li>
         </ul>
-        <p>You can exercise these rights by contacting us at <a href="mailto:info@fasolt.app" class="text-accent hover:underline">info@fasolt.app</a>. Where available, you can also use in-product export and account deletion features.</p>
+        <p>You can exercise these rights by contacting us at <a href="mailto:info@fasolt.app" class="text-accent-text hover:underline">info@fasolt.app</a>. Where available, you can also use in-product export and account deletion features.</p>
         <p>We do not use automated decision-making with legal or similarly significant effects within the meaning of Art. 22 GDPR. Review scheduling is automated, but it only affects study timing inside the service.</p>
-        <p>You also have the right to lodge a complaint with a supervisory authority. The competent authority is the <strong class="text-foreground">Landesbeauftragte für den Datenschutz und die Informationsfreiheit Baden-Württemberg</strong> (<a href="https://www.baden-wuerttemberg.datenschutz.de" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">www.baden-wuerttemberg.datenschutz.de</a>).</p>
+        <p>You also have the right to lodge a complaint with a supervisory authority. The competent authority is the <strong class="text-foreground">Landesbeauftragte für den Datenschutz und die Informationsfreiheit Baden-Württemberg</strong> (<a href="https://www.baden-wuerttemberg.datenschutz.de" target="_blank" rel="noopener noreferrer" class="text-accent-text hover:underline">www.baden-wuerttemberg.datenschutz.de</a>).</p>
       </section>
 
       <section class="space-y-2">
@@ -120,7 +120,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
 
       <section class="space-y-2">
         <h2 class="text-sm font-semibold text-foreground">13. Contact</h2>
-        <p>For questions about this privacy policy or your data, email us at <a href="mailto:info@fasolt.app" class="text-accent hover:underline">info@fasolt.app</a>.</p>
+        <p>For questions about this privacy policy or your data, email us at <a href="mailto:info@fasolt.app" class="text-accent-text hover:underline">info@fasolt.app</a>.</p>
       </section>
     </div>
   </div>

--- a/fasolt.client/src/views/ProgressView.vue
+++ b/fasolt.client/src/views/ProgressView.vue
@@ -73,12 +73,14 @@ function bucket(count: number): number {
   return 1
 }
 
+// Heatmap buckets are accent-tinted via color-mix so both themes derive from
+// the single brand token — calm, flat, never neon. Empty = sunken paper.
 function cellColor(v: number): string {
   if (v === 0) return 'var(--paper-2)'
-  if (v === 1) return 'oklch(0.85 0.07 50)'
-  if (v === 2) return 'oklch(0.75 0.12 48)'
-  if (v === 3) return 'oklch(0.65 0.15 42)'
-  return 'oklch(0.56 0.18 38)'
+  if (v === 1) return 'color-mix(in oklab, var(--accent) 22%, var(--paper-2))'
+  if (v === 2) return 'color-mix(in oklab, var(--accent) 46%, var(--paper-2))'
+  if (v === 3) return 'color-mix(in oklab, var(--accent) 72%, var(--paper-2))'
+  return 'var(--accent)'
 }
 
 // Heatmap layout: 53 columns x 7 rows for "year", weekday-aligned.
@@ -209,7 +211,7 @@ const ratingMixTotal = computed(() => {
           </div>
           <div class="big-stat-row">
             <span class="big-stat-num fa-num accent">{{ currentStreak }}</span>
-            <span class="big-stat-unit fa-mono">days</span>
+            <span class="big-stat-unit">days</span>
           </div>
           <p class="big-stat-sub">active · best {{ bestStreak }}</p>
         </div>
@@ -246,19 +248,19 @@ const ratingMixTotal = computed(() => {
             </h2>
           </div>
           <div class="heatmap-legend">
-            <span class="fa-mono">less</span>
+            <span>Less</span>
             <span v-for="v in [0,1,2,3,4]" :key="v" class="legend-cell" :style="{ background: cellColor(v) }" />
-            <span class="fa-mono">more</span>
+            <span>More</span>
           </div>
         </div>
 
         <div class="heatmap" v-if="period === 'year'">
           <div class="heatmap-months">
-            <div v-for="(m, i) in columnMonthLabels" :key="i" class="heatmap-month fa-mono">{{ m }}</div>
+            <div v-for="(m, i) in columnMonthLabels" :key="i" class="heatmap-month">{{ m }}</div>
           </div>
           <div class="heatmap-grid-wrap">
             <div class="heatmap-day-col">
-              <div v-for="(d, i) in dayLabels" :key="i" class="heatmap-day-label fa-mono">{{ d }}</div>
+              <div v-for="(d, i) in dayLabels" :key="i" class="heatmap-day-label">{{ d }}</div>
             </div>
             <div class="heatmap-grid">
               <div v-for="(col, w) in heatmapCells" :key="w" class="heatmap-col">
@@ -291,13 +293,13 @@ const ratingMixTotal = computed(() => {
 
         <div class="heatmap-foot">
           <span v-if="windowBestDay">
-            Best day · <span class="fa-mono accent-text">{{ windowBestDay.count }} cards</span>
+            Best day · <span class="foot-value">{{ windowBestDay.count }} cards</span>
           </span>
           <span>
-            Avg per active day · <span class="fa-mono accent-text">{{ windowAvgPerActive }} cards</span>
+            Avg per active day · <span class="foot-value">{{ windowAvgPerActive }} cards</span>
           </span>
           <span>
-            Rest days · <span class="fa-mono accent-text">{{ windowRestDays }}</span>
+            Rest days · <span class="foot-value">{{ windowRestDays }}</span>
           </span>
         </div>
       </section>
@@ -310,7 +312,7 @@ const ratingMixTotal = computed(() => {
               <span class="fa-cap">Rating mix</span>
               <h3 class="rating-title">How you rate yourself</h3>
             </div>
-            <span class="fa-mono rating-meta">{{ windowLabel }} · {{ ratingMixTotal.toLocaleString() }} ratings</span>
+            <span class="rating-meta">{{ windowLabel }} · {{ ratingMixTotal.toLocaleString() }} ratings</span>
           </div>
           <div class="rating-bar">
             <div
@@ -328,7 +330,7 @@ const ratingMixTotal = computed(() => {
               </div>
               <div class="rating-cell-row">
                 <span class="fa-num rating-num">{{ d.n.toLocaleString() }}</span>
-                <span class="fa-mono rating-pct">{{ d.pct }}%</span>
+                <span class="fa-num rating-pct">{{ d.pct }}%</span>
               </div>
             </div>
           </div>
@@ -391,25 +393,28 @@ const ratingMixTotal = computed(() => {
   background: var(--accent-soft);
 }
 
+/* Open stat row — whitespace + a single top/bottom hairline instead of a
+   boxed, per-tile bordered grid. Hairline verticals between tiles only. */
 .big-stats {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  border: 1px solid var(--rule-1);
-  border-radius: 12px;
-  background: var(--paper-1);
+  border-top: 1px solid var(--rule-1);
+  border-bottom: 1px solid var(--rule-1);
 }
 @media (max-width: 800px) {
   .big-stats { grid-template-columns: repeat(2, 1fr); }
-  .big-stat.is-last { border-bottom: none; }
 }
 .big-stat {
-  padding: 22px 24px;
+  padding: 20px 24px;
   border-right: 1px solid var(--rule-1);
 }
-.big-stat.is-last { border-right: none; }
+.big-stat:first-child { padding-left: 4px; }
+.big-stat.is-last { border-right: none; padding-right: 4px; }
 @media (max-width: 800px) {
-  .big-stat { border-right: none; border-bottom: 1px solid var(--rule-1); }
-  .big-stat:nth-child(odd) { border-right: 1px solid var(--rule-1); }
+  .big-stat { padding-left: 24px; }
+  .big-stat:nth-child(odd) { padding-left: 4px; }
+  .big-stat:nth-child(even) { border-right: none; padding-right: 4px; }
+  .big-stat:nth-child(1), .big-stat:nth-child(2) { border-bottom: 1px solid var(--rule-1); }
 }
 .big-stat-head {
   display: flex;
@@ -452,11 +457,10 @@ const ratingMixTotal = computed(() => {
 .heatmap-legend {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 10px;
   color: var(--ink-2);
-  font-size: 11px;
+  font-size: 12px;
 }
-.heatmap-legend > .fa-mono { font-size: 11px; }
 .legend-cell {
   width: 11px;
   height: 11px;
@@ -513,7 +517,6 @@ const ratingMixTotal = computed(() => {
   aspect-ratio: 1 / 1;
   width: 100%;
   border-radius: 2.5px;
-  transition: transform .1s;
 }
 .heatmap-cell.is-today {
   outline: 1.5px solid var(--ink-0);
@@ -542,7 +545,7 @@ const ratingMixTotal = computed(() => {
   flex-wrap: wrap;
   gap: 8px;
 }
-.accent-text { color: var(--ink-0); }
+.foot-value { color: var(--ink-0); font-weight: 600; }
 
 /* Lower split */
 .lower-split {

--- a/fasolt.client/src/views/RestoreSnapshotView.vue
+++ b/fasolt.client/src/views/RestoreSnapshotView.vue
@@ -4,8 +4,6 @@ import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { useSnapshotsStore } from '@/stores/snapshots'
 import { useDecksStore } from '@/stores/decks'
 import type { SnapshotDiff, DeckDetail } from '@/types'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 
 const route = useRoute()
@@ -104,178 +102,297 @@ function formatDue(iso: string | null) {
 </script>
 
 <template>
-  <div v-if="loading" class="py-12 text-center text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="restore-state">Loading…</div>
 
-  <div v-else class="space-y-6">
-    <!-- Breadcrumb -->
-    <div class="text-[11px] text-muted-foreground">
-      <RouterLink to="/decks" class="hover:text-foreground transition-colors">Decks</RouterLink>
-      <span class="mx-1.5">/</span>
-      <RouterLink :to="`/decks/${deckId}`" class="hover:text-foreground transition-colors">{{ deck?.name }}</RouterLink>
-      <span class="mx-1.5">/</span>
-      <RouterLink :to="`/decks/${deckId}/snapshots`" class="hover:text-foreground transition-colors">Snapshots</RouterLink>
-      <span class="mx-1.5">/</span>
-      <span class="text-foreground">Restore</span>
-    </div>
+  <div v-else class="restore-page">
+    <RouterLink :to="`/decks/${deckId}/snapshots`" class="fa-back">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+      Snapshots
+    </RouterLink>
 
     <!-- Header -->
-    <div class="flex items-start justify-between">
+    <header class="restore-head">
       <div>
-        <h1 class="text-xl font-bold tracking-tight">Restore snapshot</h1>
-        <p class="text-sm text-muted-foreground mt-1">Select which changes to revert. This will restore selected cards to their snapshot state.</p>
+        <h1 class="page-title">Restore snapshot</h1>
+        <p class="restore-lede">Select which changes to revert. This restores the selected cards to their snapshot state.</p>
       </div>
-      <Button variant="outline" size="sm" class="text-sm" @click="router.push(`/decks/${deckId}/snapshots`)">
+      <button class="fa-btn" @click="router.push(`/decks/${deckId}/snapshots`)">
         Back to snapshots
-      </Button>
-    </div>
+      </button>
+    </header>
 
     <!-- Error -->
-    <div v-if="error && !diff" class="py-8 text-center text-sm text-destructive">
+    <div v-if="error && !diff" class="restore-state" style="color: var(--c-again)">
       {{ error }}
     </div>
 
     <!-- Empty diff -->
-    <div v-else-if="isEmpty" class="py-12 text-center text-sm text-muted-foreground">
+    <div v-else-if="isEmpty" class="restore-state">
       No differences found. The deck matches this snapshot.
     </div>
 
     <!-- Diff sections -->
-    <div v-else-if="diff" class="space-y-6">
+    <div v-else-if="diff" class="diff-sections">
       <!-- Deleted since snapshot -->
-      <div v-if="diff.deleted.length > 0">
-        <div class="flex items-center gap-2 mb-3">
-          <Badge variant="destructive" class="text-xs">Deleted</Badge>
-          <span class="text-sm text-muted-foreground">{{ diff.deleted.length }} card{{ diff.deleted.length !== 1 ? 's' : '' }} removed since snapshot</span>
+      <section v-if="diff.deleted.length > 0">
+        <div class="sec-head">
+          <span class="sec-dot" style="background: var(--c-again)" />
+          <span class="fa-cap">Deleted</span>
+          <span class="sec-meta">{{ diff.deleted.length }} card{{ diff.deleted.length !== 1 ? 's' : '' }} removed since snapshot</span>
         </div>
-        <div class="space-y-2">
-          <div
+        <div class="rows">
+          <label
             v-for="card in diff.deleted"
             :key="card.cardId"
-            class="flex items-start gap-3 rounded-lg border border-border px-4 py-3"
+            class="diff-row"
           >
             <Checkbox
               :model-value="!!selected[card.cardId]"
-              class="mt-0.5"
+              class="diff-check"
               @update:model-value="toggle(card.cardId, !!$event)"
             />
-            <div class="min-w-0 flex-1">
-              <div class="text-sm font-medium">{{ card.front }}</div>
-              <div class="text-sm text-muted-foreground mt-0.5">{{ card.back }}</div>
-              <div class="flex gap-4 mt-1 text-[11px] text-muted-foreground">
-                <span :class="card.stillExists ? 'text-amber-500' : 'text-destructive'">{{ card.stillExists ? 'unassigned' : 'deleted' }}</span>
+            <div class="diff-body">
+              <div class="diff-front">{{ card.front }}</div>
+              <div class="diff-back">{{ card.back }}</div>
+              <div class="diff-meta">
+                <span :style="{ color: card.stillExists ? 'var(--c-hard)' : 'var(--c-again)' }">{{ card.stillExists ? 'unassigned' : 'deleted' }}</span>
                 <span v-if="card.sourceFile">{{ card.sourceFile }}</span>
                 <span>stability: {{ formatStability(card.stability) }}</span>
                 <span>due: {{ formatDue(card.dueAt) }}</span>
               </div>
             </div>
-          </div>
+          </label>
         </div>
-      </div>
+      </section>
 
       <!-- Modified since snapshot -->
-      <div v-if="diff.modified.length > 0">
-        <div class="flex items-center gap-2 mb-3">
-          <Badge class="text-xs bg-amber-500/15 text-amber-500 border-amber-500/25">Modified</Badge>
-          <span class="text-sm text-muted-foreground">{{ diff.modified.length }} card{{ diff.modified.length !== 1 ? 's' : '' }} changed since snapshot</span>
+      <section v-if="diff.modified.length > 0">
+        <div class="sec-head">
+          <span class="sec-dot" style="background: var(--c-hard)" />
+          <span class="fa-cap">Modified</span>
+          <span class="sec-meta">{{ diff.modified.length }} card{{ diff.modified.length !== 1 ? 's' : '' }} changed since snapshot</span>
         </div>
-        <div class="space-y-2">
-          <div
+        <div class="rows">
+          <label
             v-for="card in diff.modified"
             :key="card.cardId"
-            class="flex items-start gap-3 rounded-lg border border-border px-4 py-3"
+            class="diff-row"
           >
             <Checkbox
               :model-value="!!selected[card.cardId]"
-              class="mt-0.5"
+              class="diff-check"
               @update:model-value="toggle(card.cardId, !!$event)"
             />
-            <div class="min-w-0 flex-1 space-y-1">
-              <div v-if="card.front !== card.currentFront || card.back !== card.currentBack" class="text-sm space-y-1">
+            <div class="diff-body">
+              <div v-if="card.front !== card.currentFront || card.back !== card.currentBack" class="diff-change">
                 <div v-if="card.front !== card.currentFront">
-                  <span class="text-sm text-muted-foreground">front: </span>
-                  <span class="line-through text-muted-foreground">{{ card.front }}</span>
-                  <span class="ml-1.5">{{ card.currentFront }}</span>
+                  <span class="diff-label">front: </span>
+                  <span class="diff-old">{{ card.front }}</span>
+                  <span class="diff-new">{{ card.currentFront }}</span>
                 </div>
                 <div v-if="card.back !== card.currentBack">
-                  <span class="text-sm text-muted-foreground">back: </span>
-                  <span class="line-through text-muted-foreground">{{ card.back }}</span>
-                  <span class="ml-1.5">{{ card.currentBack }}</span>
+                  <span class="diff-label">back: </span>
+                  <span class="diff-old">{{ card.back }}</span>
+                  <span class="diff-new">{{ card.currentBack }}</span>
                 </div>
               </div>
-              <div v-else class="text-sm font-medium truncate">{{ card.currentFront }}</div>
-              <div v-if="card.snapshotFrontSvg !== null || card.currentFrontSvg !== null || card.snapshotBackSvg !== null || card.currentBackSvg !== null" class="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
-                <span v-if="card.snapshotFrontSvg !== null || card.currentFrontSvg !== null" class="text-amber-500">front image {{ card.snapshotFrontSvg === null ? 'added' : card.currentFrontSvg === null ? 'removed' : 'changed' }}</span>
-                <span v-if="card.snapshotBackSvg !== null || card.currentBackSvg !== null" class="text-amber-500">back image {{ card.snapshotBackSvg === null ? 'added' : card.currentBackSvg === null ? 'removed' : 'changed' }}</span>
+              <div v-else class="diff-front">{{ card.currentFront }}</div>
+              <div v-if="card.snapshotFrontSvg !== null || card.currentFrontSvg !== null || card.snapshotBackSvg !== null || card.currentBackSvg !== null" class="diff-meta">
+                <span v-if="card.snapshotFrontSvg !== null || card.currentFrontSvg !== null" style="color: var(--c-hard)">front image {{ card.snapshotFrontSvg === null ? 'added' : card.currentFrontSvg === null ? 'removed' : 'changed' }}</span>
+                <span v-if="card.snapshotBackSvg !== null || card.currentBackSvg !== null" style="color: var(--c-hard)">back image {{ card.snapshotBackSvg === null ? 'added' : card.currentBackSvg === null ? 'removed' : 'changed' }}</span>
                 <button
                   type="button"
-                  class="text-[11px] underline hover:text-foreground transition-colors"
-                  @click="svgPreview = svgPreview === card.cardId ? '' : card.cardId"
+                  class="diff-view"
+                  @click.prevent="svgPreview = svgPreview === card.cardId ? '' : card.cardId"
                 >
                   {{ svgPreview === card.cardId ? 'hide' : 'view' }}
                 </button>
               </div>
-              <div v-if="svgPreview === card.cardId" class="space-y-3 mt-2 rounded border border-border p-3 bg-muted/30">
-                <div v-if="card.snapshotFrontSvg !== null || card.currentFrontSvg !== null" class="grid grid-cols-2 gap-3">
+              <div v-if="svgPreview === card.cardId" class="svg-preview">
+                <div v-if="card.snapshotFrontSvg !== null || card.currentFrontSvg !== null" class="svg-pair">
                   <div>
-                    <div class="text-xs text-muted-foreground mb-1">front image — snapshot</div>
-                    <div class="bg-background rounded p-2" v-html="card.snapshotFrontSvg || '(none)'"></div>
+                    <div class="svg-cap">front image — snapshot</div>
+                    <div class="svg-frame" v-html="card.snapshotFrontSvg || '(none)'"></div>
                   </div>
                   <div>
-                    <div class="text-xs text-muted-foreground mb-1">front image — current</div>
-                    <div class="bg-background rounded p-2" v-html="card.currentFrontSvg || '(none)'"></div>
+                    <div class="svg-cap">front image — current</div>
+                    <div class="svg-frame" v-html="card.currentFrontSvg || '(none)'"></div>
                   </div>
                 </div>
-                <div v-if="card.snapshotBackSvg !== null || card.currentBackSvg !== null" class="grid grid-cols-2 gap-3">
+                <div v-if="card.snapshotBackSvg !== null || card.currentBackSvg !== null" class="svg-pair">
                   <div>
-                    <div class="text-xs text-muted-foreground mb-1">back image — snapshot</div>
-                    <div class="bg-background rounded p-2" v-html="card.snapshotBackSvg || '(none)'"></div>
+                    <div class="svg-cap">back image — snapshot</div>
+                    <div class="svg-frame" v-html="card.snapshotBackSvg || '(none)'"></div>
                   </div>
                   <div>
-                    <div class="text-xs text-muted-foreground mb-1">back image — current</div>
-                    <div class="bg-background rounded p-2" v-html="card.currentBackSvg || '(none)'"></div>
+                    <div class="svg-cap">back image — current</div>
+                    <div class="svg-frame" v-html="card.currentBackSvg || '(none)'"></div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
+          </label>
         </div>
-      </div>
+      </section>
 
       <!-- Added since snapshot -->
-      <div v-if="diff.added.length > 0">
-        <div class="flex items-center gap-2 mb-3">
-          <Badge class="text-xs bg-green-500/15 text-green-500 border-green-500/25">Added</Badge>
-          <span class="text-sm text-muted-foreground">{{ diff.added.length }} card{{ diff.added.length !== 1 ? 's' : '' }} added since snapshot</span>
+      <section v-if="diff.added.length > 0">
+        <div class="sec-head">
+          <span class="sec-dot" style="background: var(--c-good)" />
+          <span class="fa-cap">Added</span>
+          <span class="sec-meta">{{ diff.added.length }} card{{ diff.added.length !== 1 ? 's' : '' }} added since snapshot</span>
         </div>
-        <div class="space-y-2">
+        <div class="rows">
           <div
             v-for="card in diff.added"
             :key="card.cardId"
-            class="rounded-lg border border-border px-4 py-3"
+            class="diff-row diff-row--static"
           >
-            <div class="text-sm font-medium">{{ card.front }}</div>
-            <div class="text-sm text-muted-foreground mt-0.5">{{ card.back }}</div>
+            <div class="diff-body">
+              <div class="diff-front">{{ card.front }}</div>
+              <div class="diff-back">{{ card.back }}</div>
+            </div>
           </div>
         </div>
-        <div class="text-[11px] text-muted-foreground mt-2">These cards are unaffected by restore.</div>
-      </div>
+        <p class="rows-note">These cards are unaffected by restore.</p>
+      </section>
     </div>
 
     <!-- Error on restore -->
-    <div v-if="error && diff" class="text-sm text-destructive">{{ error }}</div>
+    <div v-if="error && diff" class="restore-error" style="color: var(--c-again)">{{ error }}</div>
 
     <!-- Sticky footer -->
-    <div v-if="diff && !isEmpty" class="sticky bottom-0 bg-background border-t border-border -mx-4 px-4 py-3 flex items-center gap-3">
-      <Button variant="ghost" size="sm" class="text-sm" @click="toggleAll">
+    <div v-if="diff && !isEmpty" class="restore-footer">
+      <button class="fa-btn fa-btn-ghost" @click="toggleAll">
         {{ allSelected ? 'Deselect all' : 'Select all' }}
-      </Button>
-      <div class="flex-1 text-sm text-muted-foreground">
+      </button>
+      <div class="footer-count">
         {{ selectedCount }} card{{ selectedCount !== 1 ? 's' : '' }} selected
       </div>
-      <Button variant="outline" size="sm" @click="router.push(`/decks/${deckId}/snapshots`)">Cancel</Button>
-      <Button size="sm" :disabled="selectedCount === 0 || restoring" @click="handleRestore">
-        {{ restoring ? 'Restoring...' : 'Restore selected' }}
-      </Button>
+      <button class="fa-btn" @click="router.push(`/decks/${deckId}/snapshots`)">Cancel</button>
+      <button class="fa-btn fa-btn-primary" :disabled="selectedCount === 0 || restoring" @click="handleRestore">
+        {{ restoring ? 'Restoring…' : 'Restore selected' }}
+      </button>
     </div>
   </div>
 </template>
+
+<style scoped>
+.restore-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.restore-state {
+  padding: 48px 0;
+  text-align: center;
+  font-size: 14px;
+  color: var(--ink-2);
+}
+
+/* Header */
+.restore-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.restore-lede {
+  margin: 8px 0 0;
+  font-size: 14px;
+  color: var(--ink-2);
+  max-width: 52ch;
+}
+
+/* Diff sections */
+.diff-sections { display: flex; flex-direction: column; gap: 28px; }
+
+.sec-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.sec-dot { width: 7px; height: 7px; border-radius: 999px; flex: none; }
+.sec-meta { font-size: 13px; color: var(--ink-2); }
+
+/* Rows — hairline separators, no boxed cards */
+.rows { display: flex; flex-direction: column; }
+.diff-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 13px 4px;
+  border-bottom: 1px solid var(--rule-1);
+  cursor: pointer;
+}
+.diff-row:last-child { border-bottom: none; }
+.diff-row--static { cursor: default; }
+.diff-check { margin-top: 1px; }
+.diff-body { min-width: 0; flex: 1; display: flex; flex-direction: column; gap: 4px; }
+
+.diff-front { font-size: 14px; font-weight: 500; color: var(--ink-0); }
+.diff-back { font-size: 14px; color: var(--ink-2); }
+
+.diff-change { display: flex; flex-direction: column; gap: 4px; font-size: 14px; }
+.diff-label { color: var(--ink-2); }
+.diff-old { color: var(--ink-2); text-decoration: line-through; }
+.diff-new { margin-left: 6px; color: var(--ink-0); }
+
+.diff-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 12px;
+  color: var(--ink-2);
+}
+
+.diff-view {
+  font-size: 12px;
+  color: var(--accent-text);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+.diff-view:hover { color: var(--accent-hi); }
+
+/* SVG preview */
+.svg-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+  padding: 12px;
+  border: 1px solid var(--rule-1);
+  border-radius: 8px;
+  background: var(--paper-2);
+}
+.svg-pair { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.svg-cap { font-size: 12px; color: var(--ink-2); margin-bottom: 4px; }
+.svg-frame {
+  background: var(--paper-1);
+  border: 1px solid var(--rule-1);
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.rows-note { margin: 8px 0 0; font-size: 12px; color: var(--ink-2); }
+
+.restore-error { font-size: 14px; }
+
+/* Sticky footer */
+.restore-footer {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 -16px;
+  padding: 12px 16px;
+  background: var(--paper-0);
+  border-top: 1px solid var(--rule-1);
+}
+.footer-count { flex: 1; font-size: 13px; color: var(--ink-2); }
+</style>

--- a/fasolt.client/src/views/ReviewView.vue
+++ b/fasolt.client/src/views/ReviewView.vue
@@ -62,7 +62,7 @@ const activeDeck = computed(() => {
 const activeDeckLabel = computed(() => activeDeck.value?.name || 'All decks')
 const activeDeckColor = computed(() => deckColor(activeDeck.value?.id || 'all-decks'))
 
-const modeLabel = computed(() => review.mode === 'cram' ? 'CRAM' : 'REVIEW')
+const modeLabel = computed(() => review.mode === 'cram' ? 'Cram' : 'Review')
 </script>
 
 <template>
@@ -133,7 +133,7 @@ const modeLabel = computed(() => review.mode === 'cram' ? 'CRAM' : 'REVIEW')
     <div v-else-if="review.loading" class="state">Loading cards…</div>
 
     <div v-else-if="review.noDueCards" class="state-block">
-      <h2 class="fa-serif state-title">All caught up.</h2>
+      <h2 class="state-title">All caught up.</h2>
       <p class="state-sub">No cards are due for review right now.</p>
       <button class="fa-btn fa-btn-primary" @click="onDone">Back to study</button>
     </div>
@@ -178,7 +178,7 @@ const modeLabel = computed(() => review.mode === 'cram' ? 'CRAM' : 'REVIEW')
   gap: 14px;
   flex-wrap: wrap;
 }
-.context-mode { color: var(--accent); }
+.context-mode { color: var(--ink-2); }
 .context-vrule { width: 1px; height: 12px; background: var(--rule-1); }
 .context-deck {
   display: flex;
@@ -272,9 +272,11 @@ const modeLabel = computed(() => review.mode === 'cram' ? 'CRAM' : 'REVIEW')
   padding: 40px 0;
 }
 .state-title {
-  font-size: 56px;
+  font-family: inherit;
+  font-size: 32px;
+  font-weight: 600;
   letter-spacing: -0.03em;
-  line-height: 1;
+  line-height: 1.05;
   margin: 0;
   color: var(--ink-0);
 }

--- a/fasolt.client/src/views/SettingsView.vue
+++ b/fasolt.client/src/views/SettingsView.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
 import { useAuthStore } from '@/stores/auth'
 import { apiFetch, isApiError } from '@/api/client'
 import DeleteAccountDialog from '@/components/DeleteAccountDialog.vue'
@@ -154,164 +151,267 @@ async function savePassword() {
   <div class="settings-page">
     <h1 class="page-title">Settings</h1>
 
-    <div class="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
-      <div class="flex flex-col gap-6">
-        <Card class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-base">Account</CardTitle>
-          </CardHeader>
-          <CardContent class="flex flex-col gap-1">
-            <div class="flex items-center gap-2 text-sm">
-              <span class="text-muted-foreground">Signed in as</span>
-              <span class="font-medium">{{ auth.user?.displayName || auth.user?.email }}</span>
+    <div class="settings-grid">
+      <div class="settings-col">
+        <!-- Account -->
+        <section class="fa-section">
+          <h2 class="fa-section-head">Account</h2>
+          <div class="meta-rows">
+            <div class="meta-row">
+              <span class="meta-label">Signed in as</span>
+              <span class="meta-value">{{ auth.user?.displayName || auth.user?.email }}</span>
             </div>
-            <div class="flex items-center gap-2 text-sm">
-              <span class="text-muted-foreground">Account type</span>
-              <span v-if="auth.user?.externalProvider === 'GitHub'" class="inline-flex items-center gap-1 font-medium">
-                <svg class="h-3.5 w-3.5" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            <div class="meta-row">
+              <span class="meta-label">Account type</span>
+              <span v-if="auth.user?.externalProvider === 'GitHub'" class="meta-value provider">
+                <svg class="provider-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                 GitHub
               </span>
-              <span v-else-if="auth.user?.externalProvider === 'Apple'" class="inline-flex items-center gap-1 font-medium">
-                <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.52-3.23 0-1.44.64-2.2.52-3.06-.4C3.79 16.17 4.36 9.02 8.93 8.76c1.28.07 2.17.72 2.91.77.93-.19 1.82-.87 2.83-.79 1.19.1 2.08.6 2.67 1.5-2.44 1.47-1.86 4.7.37 5.6-.44 1.16-1.01 2.3-2.66 4.44zM12.03 8.7c-.15-2.34 1.8-4.3 3.97-4.5.29 2.56-2.34 4.48-3.97 4.5z"/></svg>
+              <span v-else-if="auth.user?.externalProvider === 'Apple'" class="meta-value provider">
+                <svg class="provider-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.52-3.23 0-1.44.64-2.2.52-3.06-.4C3.79 16.17 4.36 9.02 8.93 8.76c1.28.07 2.17.72 2.91.77.93-.19 1.82-.87 2.83-.79 1.19.1 2.08.6 2.67 1.5-2.44 1.47-1.86 4.7.37 5.6-.44 1.16-1.01 2.3-2.66 4.44zM12.03 8.7c-.15-2.34 1.8-4.3 3.97-4.5.29 2.56-2.34 4.48-3.97 4.5z"/></svg>
                 Apple
               </span>
-              <span v-else-if="auth.isExternalAccount" class="font-medium">{{ auth.user?.externalProvider }}</span>
-              <span v-else class="font-medium">Email &amp; password</span>
+              <span v-else-if="auth.isExternalAccount" class="meta-value">{{ auth.user?.externalProvider }}</span>
+              <span v-else class="meta-value">Email &amp; password</span>
             </div>
-          </CardContent>
-        </Card>
+          </div>
+        </section>
 
-        <Card v-if="!auth.isExternalAccount" class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-base">Email address</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form class="flex flex-col gap-3" @submit.prevent="saveEmail">
-              <div v-if="emailSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-sm text-success">Verification email sent. Check your inbox to confirm the change.</div>
-              <div v-if="emailError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">{{ emailError }}</div>
-              <div class="flex flex-col gap-1.5">
-                <label for="new-email" class="text-sm font-medium">New email</label>
-                <Input id="new-email" v-model="newEmail" type="email" required />
-              </div>
-              <div class="flex flex-col gap-1.5">
-                <label for="email-password" class="text-sm font-medium">Current password</label>
-                <Input id="email-password" v-model="emailCurrentPassword" type="password" required autocomplete="off" />
-              </div>
-              <Button type="submit" size="sm" class="self-start text-sm">Update email</Button>
-            </form>
-          </CardContent>
-        </Card>
+        <!-- Email address -->
+        <section v-if="!auth.isExternalAccount" class="fa-section">
+          <h2 class="fa-section-head">Email address</h2>
+          <form class="fa-form" @submit.prevent="saveEmail">
+            <p v-if="emailSuccess" class="msg msg-ok">Verification email sent. Check your inbox to confirm the change.</p>
+            <p v-if="emailError" class="msg msg-err">{{ emailError }}</p>
+            <div class="field">
+              <label for="new-email" class="field-label">New email</label>
+              <input id="new-email" v-model="newEmail" type="email" required class="fa-input" />
+            </div>
+            <div class="field">
+              <label for="email-password" class="field-label">Current password</label>
+              <input id="email-password" v-model="emailCurrentPassword" type="password" required autocomplete="off" class="fa-input" />
+            </div>
+            <button type="submit" class="fa-btn fa-btn-primary self-start">Update email</button>
+          </form>
+        </section>
 
-        <Card v-if="!auth.isExternalAccount" class="border-border/60">
-          <CardHeader>
-            <CardTitle class="text-base">Change password</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form class="flex flex-col gap-3" @submit.prevent="savePassword">
-              <div v-if="passwordSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-sm text-success">Password changed.</div>
-              <div v-if="passwordError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">{{ passwordError }}</div>
-              <div class="flex flex-col gap-1.5">
-                <label for="current-password" class="text-sm font-medium">Current password</label>
-                <Input id="current-password" v-model="currentPassword" type="password" required autocomplete="current-password" />
-              </div>
-              <div class="flex flex-col gap-1.5">
-                <label for="new-password" class="text-sm font-medium">New password</label>
-                <Input id="new-password" v-model="newPassword" type="password" required autocomplete="new-password" />
-              </div>
-              <div class="flex flex-col gap-1.5">
-                <label for="confirm-new-password" class="text-sm font-medium">Confirm new password</label>
-                <Input id="confirm-new-password" v-model="confirmNewPassword" type="password" required autocomplete="new-password" />
-              </div>
-              <Button type="submit" size="sm" class="self-start text-sm">Change password</Button>
-            </form>
-          </CardContent>
-        </Card>
+        <!-- Change password -->
+        <section v-if="!auth.isExternalAccount" class="fa-section">
+          <h2 class="fa-section-head">Change password</h2>
+          <form class="fa-form" @submit.prevent="savePassword">
+            <p v-if="passwordSuccess" class="msg msg-ok">Password changed.</p>
+            <p v-if="passwordError" class="msg msg-err">{{ passwordError }}</p>
+            <div class="field">
+              <label for="current-password" class="field-label">Current password</label>
+              <input id="current-password" v-model="currentPassword" type="password" required autocomplete="current-password" class="fa-input" />
+            </div>
+            <div class="field">
+              <label for="new-password" class="field-label">New password</label>
+              <input id="new-password" v-model="newPassword" type="password" required autocomplete="new-password" class="fa-input" />
+            </div>
+            <div class="field">
+              <label for="confirm-new-password" class="field-label">Confirm new password</label>
+              <input id="confirm-new-password" v-model="confirmNewPassword" type="password" required autocomplete="new-password" class="fa-input" />
+            </div>
+            <button type="submit" class="fa-btn fa-btn-primary self-start">Change password</button>
+          </form>
+        </section>
       </div>
 
-      <div class="flex flex-col gap-6">
-      <Card class="border-border/60">
-        <CardHeader>
-          <CardTitle class="text-base">Scheduling</CardTitle>
-          <p class="text-sm text-muted-foreground">
+      <div class="settings-col">
+        <!-- Scheduling -->
+        <section class="fa-section">
+          <h2 class="fa-section-head">Scheduling</h2>
+          <p class="section-desc">
             Adjust how the FSRS algorithm schedules your reviews.
-            <RouterLink to="/algorithm" class="text-accent hover:underline">How the algorithm works</RouterLink>
+            <RouterLink to="/algorithm" class="fa-inline-link">How the algorithm works</RouterLink>
           </p>
-        </CardHeader>
-        <CardContent>
-          <form class="flex flex-col gap-4" @submit.prevent="saveSchedulingSettings">
-            <div v-if="schedulingLoading" class="text-sm text-muted-foreground">Loading...</div>
+          <form class="fa-form" @submit.prevent="saveSchedulingSettings">
+            <div v-if="schedulingLoading" class="loading-line">Loading…</div>
             <template v-else>
-              <div v-if="schedulingSuccess" class="rounded border border-success/20 bg-success/10 px-3 py-2 text-sm text-success">Settings saved.</div>
-              <div v-if="schedulingError" class="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">{{ schedulingError }}</div>
+              <p v-if="schedulingSuccess" class="msg msg-ok">Settings saved.</p>
+              <p v-if="schedulingError" class="msg msg-err">{{ schedulingError }}</p>
 
-              <div class="flex flex-col gap-1.5">
-                <label for="desired-retention" class="text-sm font-medium">Desired retention</label>
-                <Input id="desired-retention" v-model.number="desiredRetention" type="number" min="0.70" max="0.97" step="0.01" required />
-                <p class="text-sm text-muted-foreground">
+              <div class="field">
+                <label for="desired-retention" class="field-label">Desired retention</label>
+                <input id="desired-retention" v-model.number="desiredRetention" type="number" min="0.70" max="0.97" step="0.01" required class="fa-input" />
+                <p class="field-hint">
                   How likely you want to remember a card when it comes up for review. Higher values (e.g. 0.95) mean more frequent reviews but stronger recall. Lower values (e.g. 0.85) mean fewer reviews but more forgetting. Changes apply to future reviews only — cards already scheduled keep their current due dates.
                 </p>
               </div>
 
-              <div class="flex flex-col gap-1.5">
-                <label for="maximum-interval" class="text-sm font-medium">Maximum interval (days)</label>
-                <Input id="maximum-interval" v-model.number="maximumInterval" type="number" min="1" max="36500" step="1" required />
-                <p class="text-sm text-muted-foreground">
+              <div class="field">
+                <label for="maximum-interval" class="field-label">Maximum interval (days)</label>
+                <input id="maximum-interval" v-model.number="maximumInterval" type="number" min="1" max="36500" step="1" required class="fa-input" />
+                <p class="field-hint">
                   The longest gap allowed between reviews, in days. For example, 365 means you'll see every card at least once a year. The default (36500 days ≈ 100 years) means there's effectively no cap.
                 </p>
               </div>
 
-              <div class="flex flex-col gap-1.5">
-                <label for="day-start-hour" class="text-sm font-medium">Day starts at</label>
-                <select
-                  id="day-start-hour"
-                  v-model.number="dayStartHour"
-                  class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                >
+              <div class="field">
+                <label for="day-start-hour" class="field-label">Day starts at</label>
+                <select id="day-start-hour" v-model.number="dayStartHour" class="fa-input fa-select">
                   <option v-for="h in hourOptions" :key="h" :value="h">{{ formatHourLabel(h) }}</option>
                 </select>
-                <p class="text-sm text-muted-foreground">
+                <p class="field-hint">
                   Hour at which a new study day begins, in your browser's time zone ({{ browserTimeZone }}). Cards scheduled a day or more in advance become due all at once at this time, instead of trickling in throughout the day. Sub-day learning steps still fire at their exact times.
                 </p>
               </div>
 
-              <Button type="submit" size="sm" class="self-start text-sm">Save scheduling settings</Button>
+              <button type="submit" class="fa-btn fa-btn-primary self-start">Save scheduling settings</button>
             </template>
           </form>
-        </CardContent>
-      </Card>
+        </section>
 
-      <Card class="border-border/60">
-        <CardHeader>
-          <CardTitle class="text-base">Your data</CardTitle>
-        </CardHeader>
-        <CardContent class="flex flex-col gap-3">
-          <p class="text-sm text-muted-foreground">
+        <!-- Your data -->
+        <section class="fa-section">
+          <h2 class="fa-section-head">Your data</h2>
+          <p class="section-desc">
             Download a copy of all your data (cards, decks, study progress, snapshots) as a JSON file, or permanently delete your account.
           </p>
-          <div class="flex gap-2">
-            <a href="/api/account/export" class="inline-flex">
-              <Button size="sm" class="text-sm">Export data</Button>
-            </a>
-            <Button size="sm" variant="destructive" class="text-sm" @click="deleteDialogOpen = true">
-              Delete account
-            </Button>
+          <div class="data-actions">
+            <a href="/api/account/export" class="fa-btn">Export data</a>
+            <button type="button" class="fa-btn fa-btn-danger" @click="deleteDialogOpen = true">Delete account</button>
           </div>
-        </CardContent>
-      </Card>
+        </section>
       </div>
     </div>
 
     <DeleteAccountDialog v-model:open="deleteDialogOpen" />
-
   </div>
 </template>
 
 <style scoped>
 .settings-page {
-  padding: 28px 0 40px;
+  padding: 40px 8px 48px;
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 28px;
+  max-width: 980px;
+  margin: 0 auto;
+  width: 100%;
 }
-</style>
 
+.settings-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: start;
+  gap: 36px;
+}
+@media (min-width: 768px) {
+  .settings-grid { grid-template-columns: 1fr 1fr; gap: 40px 48px; }
+}
+.settings-col { display: flex; flex-direction: column; gap: 36px; }
+
+/* Section — whitespace + a quiet head, no boxed card */
+.fa-section { display: flex; flex-direction: column; gap: 14px; }
+.fa-section-head {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink-0);
+  margin: 0;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--rule-1);
+}
+.section-desc {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  margin: 0;
+}
+
+/* Account meta — hairline rows */
+.meta-rows { display: flex; flex-direction: column; }
+.meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--rule-1);
+}
+.meta-row:last-child { border-bottom: none; }
+.meta-label { font-size: 13.5px; color: var(--ink-2); }
+.meta-value { font-size: 13.5px; color: var(--ink-0); font-weight: 500; }
+.meta-value.provider { display: inline-flex; align-items: center; gap: 6px; }
+.provider-icon { width: 14px; height: 14px; }
+
+/* Forms */
+.fa-form { display: flex; flex-direction: column; gap: 16px; }
+.field { display: flex; flex-direction: column; gap: 6px; }
+.field-label { font-size: 13px; font-weight: 600; color: var(--ink-0); }
+.field-hint {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ink-2);
+  margin: 0;
+}
+
+/* Flat inputs — paper-2 fill, hairline, accent focus ring */
+.fa-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 11px;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--ink-0);
+  background: var(--paper-2);
+  border: 1px solid var(--rule-1);
+  border-radius: 8px;
+  outline: none;
+  transition: border-color .12s, box-shadow .12s;
+}
+.fa-input::placeholder { color: var(--ink-2); }
+.fa-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.fa-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%238e8e93' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 30px;
+}
+
+/* Inline message banners — quiet, token-driven */
+.msg {
+  font-size: 13px;
+  line-height: 1.45;
+  padding: 9px 11px;
+  border-radius: 8px;
+  margin: 0;
+}
+.msg-ok {
+  color: var(--c-good);
+  background: color-mix(in oklab, var(--c-good) 10%, transparent);
+  border: 1px solid color-mix(in oklab, var(--c-good) 28%, transparent);
+}
+.msg-err {
+  color: var(--c-again);
+  background: color-mix(in oklab, var(--c-again) 10%, transparent);
+  border: 1px solid color-mix(in oklab, var(--c-again) 28%, transparent);
+}
+
+.loading-line { font-size: 13.5px; color: var(--ink-2); }
+
+/* Inline link — accent as text */
+.fa-inline-link { color: var(--accent-text); text-decoration: none; }
+.fa-inline-link:hover { text-decoration: underline; }
+
+/* Data section actions */
+.data-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+.fa-btn-danger {
+  color: var(--c-again);
+  border-color: color-mix(in oklab, var(--c-again) 40%, var(--rule-1));
+  background: transparent;
+}
+.fa-btn-danger:hover {
+  background: color-mix(in oklab, var(--c-again) 10%, transparent);
+  border-color: var(--c-again);
+}
+
+.self-start { align-self: flex-start; }
+</style>

--- a/fasolt.client/src/views/SourcesView.vue
+++ b/fasolt.client/src/views/SourcesView.vue
@@ -2,8 +2,6 @@
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSourcesStore } from '@/stores/sources'
-import { Card, CardContent } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 
 const router = useRouter()
 const sourcesStore = useSourcesStore()
@@ -15,45 +13,84 @@ onMounted(() => sourcesStore.fetchSources())
   <div class="sources-page">
     <div>
       <h1 class="page-title">Sources</h1>
-      <p class="text-sm text-muted-foreground mt-1">
-        Files your cards were created from.
-      </p>
+      <p class="page-sub">Files your cards were created from.</p>
     </div>
 
-    <div v-if="sourcesStore.loading" class="py-12 text-center text-xs text-muted-foreground">Loading...</div>
+    <div v-if="sourcesStore.loading" class="empty">Loading…</div>
 
-    <div v-else class="grid gap-2.5 sm:grid-cols-2">
-      <Card
+    <div v-else-if="sourcesStore.sources.length === 0" class="empty">
+      No sources yet. Use the MCP agent to create cards from your markdown notes.
+    </div>
+
+    <div v-else class="source-list">
+      <button
         v-for="source in sourcesStore.sources"
         :key="source.sourceFile"
-        class="cursor-pointer border-border/60 hover:border-accent/30 transition-colors"
+        class="source-row"
         @click="router.push(`/cards?sourceFile=${encodeURIComponent(source.sourceFile)}`)"
       >
-        <CardContent class="flex items-center justify-between p-4">
-          <div class="min-w-0">
-            <div class="truncate text-sm font-medium text-foreground">{{ source.sourceFile }}</div>
-            <div class="mt-0.5 text-[11px] text-muted-foreground">{{ source.cardCount }} cards</div>
-          </div>
-          <div class="ml-3 flex shrink-0 items-center gap-2">
-            <Badge v-if="source.dueCount > 0" variant="outline" class="text-[10px] text-warning border-warning/30">
-              {{ source.dueCount }} due
-            </Badge>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-
-    <div v-if="!sourcesStore.loading && sourcesStore.sources.length === 0" class="py-12 text-center text-xs text-muted-foreground">
-      No sources yet. Use the MCP agent to create cards from your markdown notes.
+        <div class="source-row-text">
+          <div class="source-row-name">{{ source.sourceFile }}</div>
+          <div class="source-row-sub">{{ source.cardCount }} cards</div>
+        </div>
+        <div v-if="source.dueCount > 0" class="source-row-due fa-num">{{ source.dueCount }} due</div>
+        <svg class="source-chevron" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 6 6 6-6 6"/></svg>
+      </button>
     </div>
   </div>
 </template>
 
 <style scoped>
 .sources-page {
-  padding: 28px 0 40px;
+  padding: 40px 8px 48px;
+  max-width: 760px;
+  margin: 0 auto;
+  width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 24px;
+}
+.page-sub {
+  margin: 6px 0 0;
+  font-size: 13.5px;
+  color: var(--ink-2);
+}
+
+/* Source list — rows on the page, hairline separators, no outer box */
+.source-list { display: flex; flex-direction: column; }
+.source-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 15px 4px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--rule-1);
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  transition: background .12s;
+}
+.source-row:last-child { border-bottom: none; }
+.source-row:hover { background: var(--paper-2); }
+.source-row-text { flex: 1; min-width: 0; }
+.source-row-name {
+  font-size: 15.5px;
+  color: var(--ink-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.source-row-sub { font-size: 12.5px; color: var(--ink-2); margin-top: 1px; }
+.source-row-due { font-size: 14px; color: var(--accent-text); font-weight: 600; flex: none; }
+.source-chevron { color: var(--ink-3); flex: none; }
+
+/* Empty / loading state */
+.empty {
+  padding: 24px 0;
+  color: var(--ink-2);
+  font-size: 13.5px;
 }
 </style>

--- a/fasolt.client/src/views/StudyView.vue
+++ b/fasolt.client/src/views/StudyView.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import { useReviewStore } from '@/stores/review'
 import { useDecksStore } from '@/stores/decks'
 import { apiFetch } from '@/api/client'
-import type { Deck, DailyActivity, Progress, StudyStats } from '@/types'
+import type { Deck, StudyStats } from '@/types'
 import { deckColor } from '@/lib/utils'
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts'
 
@@ -19,7 +19,6 @@ const dueCount = ref(0)
 const studiedToday = ref(0)
 const creatingDemo = ref(false)
 const studyStats = ref<StudyStats>({ currentStreak: 0, bestStreak: 0, totalAnswered: 0, answeredToday: 0 })
-const streakActivity = ref<DailyActivity[]>([])
 
 onMounted(async () => {
   try {
@@ -29,10 +28,6 @@ onMounted(async () => {
     studiedToday.value = stats.studiedToday
   } catch { /* leave as 0 */ }
   try { studyStats.value = await reviewStore.fetchStudyStats() } catch { /* leave at zeros */ }
-  try {
-    const progress = await apiFetch<Progress>('/review/progress?days=14')
-    streakActivity.value = progress.dailyActivity
-  } catch { /* leave empty — strip falls back to flat zero state */ }
   decksStore.fetchDecks()
 
   register({
@@ -53,6 +48,10 @@ const sortedDecks = computed(() => {
 const decksWithDue = computed(() => decksStore.decks.filter(d => !d.isSuspended && d.dueCount > 0).length)
 const activeDeckCount = computed(() => decksStore.decks.filter(d => !d.isSuspended).length)
 
+// The "Today" star carries meaning: filled/amber once you've reviewed at least
+// one card today (streak safe), hollow/muted until then.
+const reviewedToday = computed(() => (studyStats.value.answeredToday || 0) > 0)
+
 async function createDemoDeck() {
   creatingDemo.value = true
   try {
@@ -66,142 +65,87 @@ function startReview(deckId?: string) {
   else router.push('/review')
 }
 
-// Streak strip — real per-day reviews from /review/progress?days=14, bucketed
-// 0..4 relative to the window max. Empty array (pre-fetch or error) renders as
-// a flat zero strip with today highlighted.
-type StreakBar = { count: number; bucket: number; date: string | null; isToday: boolean }
-
-const streakBars = computed<StreakBar[]>(() => {
-  const data = streakActivity.value
-  if (data.length === 0) {
-    return Array.from({ length: 14 }, (_, i) => ({
-      count: 0, bucket: 0, date: null, isToday: i === 13,
-    }))
-  }
-  const max = Math.max(1, ...data.map(d => d.count))
-  return data.map((d, i) => {
-    const ratio = d.count / max
-    let bucket = 0
-    if (d.count > 0) {
-      if (ratio >= 0.85) bucket = 4
-      else if (ratio >= 0.55) bucket = 3
-      else if (ratio >= 0.30) bucket = 2
-      else bucket = 1
-    }
-    return { count: d.count, bucket, date: d.date, isToday: i === data.length - 1 }
-  })
-})
-
-function streakBarTitle(b: StreakBar): string {
-  if (!b.date) return b.isToday ? 'Today' : ''
-  const [y, m, day] = b.date.split('-').map(Number)
-  const label = new Date(y, m - 1, day).toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
-  const verb = b.count === 1 ? 'review' : 'reviews'
-  return `${b.isToday ? 'Today · ' : ''}${label} · ${b.count} ${verb}`
+// Things-style progress ring: how much of a deck is due. r=16 → circumference ≈ 100.53.
+const RING_C = 100.53
+function ringDash(deck: Deck): string {
+  const pct = deck.cardCount ? Math.min(1, deck.dueCount / deck.cardCount) : 0
+  return `${(pct * RING_C).toFixed(1)} ${RING_C}`
 }
 </script>
 
 <template>
   <div class="study-page">
-    <!-- Hero row: due number + streak panel -->
+    <!-- Hero -->
     <section class="hero">
-      <div class="hero-due">
-        <div class="hero-due-stack">
-          <div class="hero-number-wrap">
-            <span class="hero-number fa-num">{{ dueCount }}</span>
-            <span class="hero-descriptor">
-              <template v-if="dueCount > 0">
-                cards due<br />
-                <template v-if="decksWithDue > 0">
-                  across <strong>{{ decksWithDue }} {{ decksWithDue === 1 ? 'deck' : 'decks' }}</strong>
-                </template>
-                <template v-else>
-                  across <strong>your library</strong>
-                </template>
-              </template>
-              <template v-else-if="totalCards > 0">
-                cards due<br />
-                <strong>all caught up</strong>
-              </template>
-              <template v-else>
-                cards total<br />
-                <strong>add your first cards</strong>
-              </template>
-            </span>
-          </div>
-          <div class="hero-actions">
-            <button
-              v-if="dueCount > 0"
-              class="fa-btn fa-btn-primary hero-cta"
-              @click="startReview()"
-            >
-              Start reviewing
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
-              <span class="cta-kbd">↵</span>
-            </button>
-            <button
-              v-else-if="totalCards === 0"
-              class="fa-btn fa-btn-primary hero-cta"
-              :disabled="creatingDemo"
-              @click="createDemoDeck"
-            >
-              {{ creatingDemo ? 'Creating…' : 'Create a demo deck' }}
-            </button>
-            <RouterLink to="/decks" class="fa-btn" style="height:40px;padding:0 14px;">Browse decks</RouterLink>
-            <RouterLink to="/mcp-setup" class="fa-btn fa-btn-ghost" style="height:40px;color:var(--ink-2);">Connect your AI</RouterLink>
-          </div>
-        </div>
+      <div
+        class="today-row"
+        :class="{ 'is-pending': !reviewedToday }"
+        :title="reviewedToday ? 'You\'ve reviewed today — your streak is safe' : 'No reviews yet today — review to keep your streak going'"
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" :fill="reviewedToday ? 'currentColor' : 'none'" stroke="currentColor" :stroke-width="reviewedToday ? 0 : 1.7" stroke-linejoin="round" aria-hidden="true"><path d="M12 2l2.9 6.3 6.9.6-5.2 4.5 1.6 6.7L12 17.3 5.8 20.6l1.6-6.7L2.2 8.9l6.9-.6z"/></svg>
+        Today
       </div>
 
-      <aside class="hero-streak">
-        <div class="streak-head">
-          <span class="fa-cap">Streak</span>
-          <span class="fa-mono streak-range">last 14 days</span>
-        </div>
-        <div class="streak-num-row">
-          <span class="streak-num fa-num">{{ studyStats.currentStreak }}</span>
-          <span class="streak-meta">
-            days · best {{ studyStats.bestStreak }}
-            <template v-if="studyStats.currentStreak > 0"> 🔥</template>
-          </span>
-        </div>
-        <div class="streak-bars">
-          <div
-            v-for="(b, i) in streakBars"
-            :key="i"
-            class="streak-bar"
-            :class="{ 'is-today': b.isToday, 'is-rest': b.bucket === 0 }"
-            :style="{
-              height: `${12 + b.bucket * 8}px`,
-              background: b.isToday
-                ? 'var(--accent)'
-                : b.bucket === 0
-                  ? 'var(--rule-1)'
-                  : `oklch(0.55 0.13 155 / ${0.35 + b.bucket * 0.12})`,
-            }"
-            :title="streakBarTitle(b)"
-          />
-        </div>
-        <div class="streak-axis">
-          <span class="fa-mono">2w</span>
-          <span class="fa-mono">today</span>
-        </div>
-      </aside>
+      <div class="hero-main">
+        <span class="hero-number fa-num">{{ dueCount > 0 || totalCards > 0 ? dueCount : 0 }}</span>
+        <span class="hero-descriptor">
+          <template v-if="dueCount > 0">
+            cards due<br />
+            <template v-if="decksWithDue > 0">
+              across <strong>{{ decksWithDue }} {{ decksWithDue === 1 ? 'deck' : 'decks' }}</strong>
+            </template>
+            <template v-else>
+              across <strong>your library</strong>
+            </template>
+          </template>
+          <template v-else-if="totalCards > 0">
+            cards due<br />
+            <strong>all caught up</strong>
+          </template>
+          <template v-else>
+            cards yet<br />
+            <strong>add your first cards</strong>
+          </template>
+        </span>
+      </div>
+
+      <div class="hero-actions">
+        <button
+          v-if="dueCount > 0"
+          class="fa-btn fa-btn-primary hero-cta"
+          @click="startReview()"
+        >
+          Start reviewing
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+          <span class="cta-kbd">↵</span>
+        </button>
+        <button
+          v-else-if="totalCards === 0"
+          class="fa-btn fa-btn-primary hero-cta"
+          :disabled="creatingDemo"
+          @click="createDemoDeck"
+        >
+          {{ creatingDemo ? 'Creating…' : 'Create a demo deck' }}
+        </button>
+
+        <span v-if="studyStats.currentStreak > 0" class="streak-inline">
+          <strong>{{ studyStats.currentStreak }}-day streak</strong> · best {{ studyStats.bestStreak }}
+        </span>
+        <span v-else-if="totalCards > 0" class="streak-inline">review today to start a streak</span>
+      </div>
+
+      <div class="hero-sub-actions">
+        <RouterLink to="/decks" class="fa-btn">Browse decks</RouterLink>
+        <RouterLink to="/mcp-setup" class="fa-btn fa-btn-ghost">Connect your AI</RouterLink>
+      </div>
     </section>
 
-    <div class="fa-rule" />
-
-    <!-- Decks list -->
+    <!-- Decks with cards due -->
     <section class="decks-section">
       <header class="section-head">
-        <div class="section-head-text">
-          <h2>Decks with cards due</h2>
-          <span class="fa-cap">
-            {{ decksWithDue }} of {{ activeDeckCount }} active
-          </span>
-        </div>
-        <RouterLink v-if="activeDeckCount > 0" to="/decks" class="fa-link section-head-link">All decks ›</RouterLink>
+        <h2>Decks with cards due</h2>
       </header>
+
       <div v-if="decksStore.loading" class="empty">Loading decks…</div>
       <div v-else-if="activeDeckCount === 0" class="empty">
         <span>No decks yet.</span>
@@ -211,89 +155,37 @@ function streakBarTitle(b: StreakBar): string {
         <span>All caught up — nothing due right now.</span>
         <RouterLink to="/decks" class="fa-link">Browse all decks</RouterLink>
       </div>
+
       <div v-else class="deck-list">
         <button
           v-for="deck in sortedDecks"
           :key="deck.id"
           class="deck-row"
-          :class="{ 'is-suspended': deck.isSuspended }"
           @click="startReview(deck.id)"
         >
+          <svg class="deck-ring" width="22" height="22" viewBox="0 0 36 36" aria-hidden="true">
+            <circle cx="18" cy="18" r="16" fill="none" stroke="var(--rule-1)" stroke-width="3" />
+            <circle cx="18" cy="18" r="16" fill="none" stroke="var(--accent)" stroke-width="3" stroke-linecap="round" :stroke-dasharray="ringDash(deck)" transform="rotate(-90 18 18)" />
+          </svg>
           <span class="fa-tag" :style="{ background: deckColor(deck.id) }" />
           <div class="deck-row-text">
             <div class="deck-row-name">{{ deck.name }}</div>
-            <div class="fa-mono deck-row-sub">
-              {{ deck.cardCount }} cards<template v-if="deck.isSuspended"> · suspended</template>
-            </div>
+            <div class="deck-row-sub">{{ deck.cardCount }} cards</div>
           </div>
-          <div class="deck-row-bar">
-            <div
-              class="deck-row-bar-fill"
-              :style="{
-                width: `${deck.cardCount ? Math.min(100, (deck.dueCount / deck.cardCount) * 100) : 0}%`,
-                background: deck.dueCount > 0 ? 'var(--accent)' : 'var(--rule-1)',
-              }"
-            />
-          </div>
-          <div
-            class="fa-mono deck-row-due"
-            :class="{ 'has-due': deck.dueCount > 0 }"
-          >
-            {{ deck.dueCount > 0 ? `${deck.dueCount} due` : '—' }}
-          </div>
-          <div class="deck-row-cta">
-            <span v-if="deck.dueCount > 0 && !deck.isSuspended" class="fa-btn fa-btn-accent deck-cta-btn">
-              Review
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
-            </span>
-            <span v-else class="fa-cap" style="font-size:9px;">
-              {{ deck.isSuspended ? 'paused' : 'caught up' }}
-            </span>
-          </div>
-          <svg class="deck-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m9 6 6 6-6 6"/></svg>
+          <div class="deck-row-due">{{ deck.dueCount }} due</div>
+          <svg class="deck-chevron" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 6 6 6-6 6"/></svg>
         </button>
       </div>
     </section>
 
-    <!-- Stats tiles -->
-    <section class="stats-row">
-      <div class="stat-tile">
-        <div class="stat-head">
-          <span class="fa-cap">Current streak</span>
-          <span v-if="studyStats.currentStreak > 0" class="fa-pulse" />
-        </div>
-        <div class="stat-value-row">
-          <span class="stat-value fa-num">{{ studyStats.currentStreak }}</span>
-          <span class="stat-unit fa-mono">days</span>
-        </div>
-        <span class="stat-sub">
-          {{ studyStats.currentStreak > 0 ? `🔥 don't break it tonight` : 'review today to start a streak' }}
-        </span>
-      </div>
-      <div class="stat-tile">
-        <span class="fa-cap">Best streak</span>
-        <div class="stat-value-row">
-          <span class="stat-value fa-num">{{ studyStats.bestStreak }}</span>
-          <span class="stat-unit fa-mono">days</span>
-        </div>
-        <span class="stat-sub">all time</span>
-      </div>
-      <div class="stat-tile">
-        <span class="fa-cap">Total answered</span>
-        <div class="stat-value-row">
-          <span class="stat-value fa-num">{{ studyStats.totalAnswered.toLocaleString() }}</span>
-        </div>
-        <span class="stat-sub">across {{ totalCards }} cards</span>
-      </div>
-      <div class="stat-tile is-last">
-        <span class="fa-cap">Today</span>
-        <div class="stat-value-row">
-          <span class="stat-value fa-num">{{ studyStats.answeredToday }}</span>
-          <span class="stat-unit fa-mono">answered</span>
-        </div>
-        <span class="stat-sub">{{ studiedToday > 0 ? `${studiedToday} unique cards` : 'no reviews yet' }}</span>
-      </div>
-    </section>
+    <!-- Quiet stats line — info without the bordered tile grid -->
+    <p v-if="totalCards > 0" class="stats-line">
+      <span><strong>{{ studyStats.answeredToday }}</strong> answered today</span>
+      <span class="dot">·</span>
+      <span><strong>{{ studyStats.totalAnswered.toLocaleString() }}</strong> all time</span>
+      <span class="dot">·</span>
+      <span><strong>{{ totalCards }}</strong> cards in your library</span>
+    </p>
   </div>
 </template>
 
@@ -301,173 +193,102 @@ function streakBarTitle(b: StreakBar): string {
 .study-page {
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  padding: 36px 8px 40px;
-}
-.hero {
-  display: grid;
-  grid-template-columns: 1.35fr 1fr;
-  gap: 36px;
-  align-items: stretch;
-}
-@media (max-width: 900px) {
-  .hero { grid-template-columns: 1fr; gap: 24px; }
+  gap: 40px;
+  padding: 40px 8px 48px;
+  max-width: 760px;
+  margin: 0 auto;
+  width: 100%;
 }
 
-/* Due number column */
-.hero-due {
+/* Hero */
+.today-row {
   display: flex;
-  flex-direction: column;
-  min-height: 280px;
+  align-items: center;
+  gap: 7px;
+  color: var(--accent-text);
+  font-size: 14px;
+  font-weight: 600;
 }
-.hero-due-stack {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-}
-.hero-number-wrap {
+/* Streak not yet kept today — hollow, muted. */
+.today-row.is-pending { color: var(--ink-3); }
+.hero-main {
+  margin: 12px 0 22px;
   display: flex;
   align-items: flex-end;
-  gap: 18px;
+  gap: 16px;
 }
 .hero-number {
-  font-size: 132px;
+  font-size: 76px;
   line-height: 0.85;
   letter-spacing: -0.04em;
   color: var(--ink-0);
-  font-weight: 500;
+  font-weight: 600;
 }
 .hero-descriptor {
-  padding-bottom: 12px;
-  color: var(--ink-1);
+  padding-bottom: 8px;
+  color: var(--ink-2);
   font-size: 15px;
-  line-height: 1.4;
-  max-width: 220px;
+  line-height: 1.35;
 }
 .hero-descriptor strong { color: var(--ink-0); font-weight: 600; }
 .hero-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-top: 24px;
+  gap: 16px;
   flex-wrap: wrap;
 }
 .hero-cta {
   height: 40px;
   padding: 0 18px;
   font-size: 14px;
-  font-weight: 600;
 }
 .cta-kbd {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-left: 4px;
+  margin-left: 2px;
   width: 18px;
   height: 18px;
-  font-family: 'Geist Mono', monospace;
   font-size: 11px;
-  background: oklch(1 0 0 / .15);
-  border: 1px solid oklch(1 0 0 / .25);
+  background: rgba(255,255,255,.18);
   border-radius: 4px;
   color: inherit;
 }
+.streak-inline { font-size: 13px; color: var(--ink-2); }
+.streak-inline strong { color: var(--ink-0); font-weight: 500; }
+.hero-sub-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+.hero-sub-actions .fa-btn { height: 36px; }
 
 @media (max-width: 600px) {
-  .hero-number { font-size: 96px; }
+  .hero-number { font-size: 60px; }
 }
 
-/* Streak panel */
-.hero-streak {
-  display: flex;
-  flex-direction: column;
-  padding: 20px;
-  border: 1px solid var(--rule-1);
-  border-radius: 12px;
-  background: var(--paper-1);
-  justify-content: space-between;
-  min-height: 280px;
-}
-.streak-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-}
-.streak-range { font-size: 11px; color: var(--ink-2); }
-.streak-num-row {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  margin-top: 10px;
-}
-.streak-num {
-  font-size: 64px;
-  line-height: 0.9;
-  letter-spacing: -0.03em;
-  font-weight: 500;
-}
-.streak-meta {
-  font-size: 13px;
-  color: var(--ink-1);
-  padding-bottom: 6px;
-}
-.streak-bars {
-  display: flex;
-  align-items: flex-end;
-  gap: 4px;
-  height: 64px;
-  margin-top: 12px;
-}
-.streak-bar {
-  flex: 1;
-  border-radius: 2px;
-  min-height: 6px;
-  transition: background .2s;
-}
-.streak-bar.is-today {
-  box-shadow: 0 0 0 2px var(--accent-soft);
-}
-.streak-axis {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 6px;
-  color: var(--ink-3);
-  font-size: 10px;
-}
-
-/* Section heads */
+/* Section head */
 .section-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  margin-bottom: 14px;
+  margin-bottom: 6px;
 }
-.section-head-text {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-}
-.section-head-text h2 {
-  font-size: 20px;
+.section-head h2 {
+  font-size: 16px;
   font-weight: 600;
   letter-spacing: -0.01em;
   margin: 0;
+  color: var(--ink-1);
 }
-
-/* Deck list */
-.deck-list {
-  border: 1px solid var(--rule-1);
-  border-radius: 12px;
-  background: var(--paper-1);
-  overflow: hidden;
-}
+/* Deck list — rows on the page, hairline separators, no outer box */
+.deck-list { display: flex; flex-direction: column; }
 .deck-row {
-  display: grid;
-  grid-template-columns: 16px minmax(160px, 1.4fr) 1fr 80px 100px 22px;
+  display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 14px 18px;
+  gap: 14px;
+  padding: 15px 4px;
   width: 100%;
   text-align: left;
   background: transparent;
@@ -480,99 +301,36 @@ function streakBarTitle(b: StreakBar): string {
 }
 .deck-row:last-child { border-bottom: none; }
 .deck-row:hover { background: var(--paper-2); }
-.deck-row.is-suspended { opacity: 0.55; }
-.deck-row-text { min-width: 0; }
+.deck-ring { flex: none; }
+.deck-row-text { flex: 1; min-width: 0; }
 .deck-row-name {
-  font-weight: 500;
-  font-size: 14px;
+  font-size: 15.5px;
   color: var(--ink-0);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.deck-row-sub {
-  font-size: 11px;
-  color: var(--ink-2);
-  margin-top: 2px;
-}
-.deck-row-bar {
-  height: 4px;
-  background: var(--paper-2);
-  border-radius: 2px;
-  overflow: hidden;
-}
-.deck-row-bar-fill {
-  height: 100%;
-  transition: width .2s;
-}
-.deck-row-due {
-  font-size: 13px;
-  color: var(--ink-3);
-  text-align: right;
-  font-weight: 400;
-}
-.deck-row-due.has-due {
-  color: var(--ink-0);
-  font-weight: 600;
-}
-.deck-row-cta { display: flex; justify-content: flex-end; }
-.deck-cta-btn {
-  height: 26px;
-  padding: 0 10px;
-  font-size: 11.5px;
-  pointer-events: none;
-}
-.deck-chevron { color: var(--ink-3); justify-self: end; }
+.deck-row-sub { font-size: 12.5px; color: var(--ink-2); margin-top: 1px; }
+.deck-row-due { font-size: 14px; color: var(--accent-text); font-weight: 600; }
+.deck-chevron { color: var(--ink-3); flex: none; }
 
-/* Stats row */
-.stats-row {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  border: 1px solid var(--rule-1);
-  border-radius: 12px;
-  background: var(--paper-1);
-}
-@media (max-width: 800px) {
-  .stats-row { grid-template-columns: repeat(2, 1fr); }
-  .stat-tile.is-last { border-bottom: none; }
-}
-.stat-tile {
-  padding: 20px 22px;
+/* Quiet stats line */
+.stats-line {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  border-right: 1px solid var(--rule-1);
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--ink-2);
+  margin: 0;
 }
-.stat-tile.is-last { border-right: none; }
-@media (max-width: 800px) {
-  .stat-tile { border-right: none; border-bottom: 1px solid var(--rule-1); }
-  .stat-tile:nth-child(odd) { border-right: 1px solid var(--rule-1); }
-}
-.stat-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.stat-value-row {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  margin-top: 8px;
-}
-.stat-value {
-  font-size: 32px;
-  line-height: 1;
-  font-weight: 500;
-}
-.stat-unit { font-size: 11px; color: var(--ink-2); }
-.stat-sub { font-size: 11.5px; color: var(--ink-2); }
+.stats-line strong { color: var(--ink-0); font-weight: 600; }
+.stats-line .dot { color: var(--ink-3); }
 
 /* Empty state */
 .empty {
-  padding: 28px 0;
+  padding: 24px 0;
   color: var(--ink-2);
-  font-size: 13px;
-  text-align: center;
+  font-size: 13.5px;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/fasolt.client/src/views/TermsOfServiceView.vue
+++ b/fasolt.client/src/views/TermsOfServiceView.vue
@@ -6,7 +6,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
 
 <template>
   <div class="flex min-h-screen flex-col bg-background text-foreground">
-    <nav class="sticky top-0 z-50 border-b border-border/60 bg-background/80 backdrop-blur-md">
+    <nav class="sticky top-0 z-50 border-b border-rule-1 bg-paper-0">
       <div class="mx-auto flex max-w-3xl items-center px-6 py-4">
         <RouterLink to="/" class="flex items-center">
           <FasoltWordmark :size="32" />
@@ -76,7 +76,7 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
           <h2 class="text-sm font-semibold text-foreground">10. Privacy</h2>
           <p>
             Our processing of personal data is described in the
-            <RouterLink to="/privacy" class="text-accent hover:underline">Privacy Policy</RouterLink>.
+            <RouterLink to="/privacy" class="text-accent-text hover:underline">Privacy Policy</RouterLink>.
           </p>
         </section>
 
@@ -90,9 +90,9 @@ import FasoltWordmark from '@/components/FasoltWordmark.vue'
           <h2 class="text-sm font-semibold text-foreground">12. Contact</h2>
           <p>
             For questions about these terms, email us at
-            <a href="mailto:info@fasolt.app" class="text-accent hover:underline">info@fasolt.app</a>
+            <a href="mailto:info@fasolt.app" class="text-accent-text hover:underline">info@fasolt.app</a>
             or refer to the
-            <RouterLink to="/impressum" class="text-accent hover:underline">Impressum</RouterLink>.
+            <RouterLink to="/impressum" class="text-accent-text hover:underline">Impressum</RouterLink>.
           </p>
         </section>
       </div>

--- a/fasolt.client/src/views/admin/AdminLogsView.vue
+++ b/fasolt.client/src/views/admin/AdminLogsView.vue
@@ -119,24 +119,24 @@ onMounted(fetchLogs)
   <div class="space-y-4">
     <div class="flex items-center justify-between">
       <div>
-        <h2 class="text-lg font-semibold tracking-tight">Activity</h2>
-        <p class="text-sm text-muted-foreground">{{ totalCount }} entries</p>
+        <h2 class="text-lg font-semibold tracking-tight text-ink-0">Activity</h2>
+        <p class="text-sm text-ink-2">{{ totalCount }} entries</p>
       </div>
-      <Button variant="outline" size="sm" :disabled="isLoading" @click="fetchLogs">Refresh</Button>
+      <button class="fa-btn" :disabled="isLoading" @click="fetchLogs">Refresh</button>
     </div>
 
-    <div v-if="errorMessage" class="rounded-md border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive">
+    <div v-if="errorMessage" class="admin-error">
       {{ errorMessage }}
       <button class="ml-2 underline" @click="errorMessage = null">Dismiss</button>
     </div>
 
     <div class="flex flex-wrap items-end gap-3">
-      <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium text-muted-foreground" for="log-type-filter">Type</label>
+      <div class="flex flex-col gap-1.5">
+        <label class="fa-cap" for="log-type-filter">Type</label>
         <select
           id="log-type-filter"
           v-model="typeFilter"
-          class="h-10 rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          class="admin-select"
         >
           <option value="">All types</option>
           <option value="UserRegistered">Sign-ups</option>
@@ -144,20 +144,20 @@ onMounted(fetchLogs)
           <option value="Admin">Admin actions</option>
         </select>
       </div>
-      <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium text-muted-foreground" for="log-status-filter">Status</label>
+      <div class="flex flex-col gap-1.5">
+        <label class="fa-cap" for="log-status-filter">Status</label>
         <select
           id="log-status-filter"
           v-model="successFilter"
-          class="h-10 rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          class="admin-select"
         >
           <option value="">All</option>
           <option value="true">OK</option>
           <option value="false">Errors</option>
         </select>
       </div>
-      <div class="flex flex-col gap-1 flex-1 min-w-[200px]">
-        <label class="text-xs font-medium text-muted-foreground" for="log-search">Search</label>
+      <div class="flex flex-col gap-1.5 flex-1 min-w-[200px]">
+        <label class="fa-cap" for="log-search">Search</label>
         <Input
           id="log-search"
           v-model="searchQuery"
@@ -168,7 +168,7 @@ onMounted(fetchLogs)
       <Button v-if="hasActiveFilters()" variant="ghost" size="sm" @click="clearFilters">Clear</Button>
     </div>
 
-    <div class="rounded-md border">
+    <div class="fa-surface overflow-hidden">
       <Table>
         <TableHeader>
           <TableRow>
@@ -181,16 +181,16 @@ onMounted(fetchLogs)
         </TableHeader>
         <TableBody>
           <TableRow v-if="isLoading">
-            <TableCell :colspan="5" class="text-center text-muted-foreground">Loading…</TableCell>
+            <TableCell :colspan="5" class="text-center text-ink-2">Loading…</TableCell>
           </TableRow>
           <TableRow v-else-if="logs.length === 0">
-            <TableCell :colspan="5" class="text-center text-muted-foreground">No entries match the current filters.</TableCell>
+            <TableCell :colspan="5" class="text-center text-ink-2">No entries match the current filters.</TableCell>
           </TableRow>
           <TableRow v-for="l in logs" :key="l.id">
-            <TableCell class="whitespace-nowrap text-sm">{{ formatDate(l.createdAt) }}</TableCell>
+            <TableCell class="whitespace-nowrap text-sm text-ink-1">{{ formatDate(l.createdAt) }}</TableCell>
             <TableCell><Badge variant="outline">{{ typeLabel(l.type) }}</Badge></TableCell>
             <TableCell>{{ l.message }}</TableCell>
-            <TableCell class="text-muted-foreground text-sm">{{ l.detail ?? '—' }}</TableCell>
+            <TableCell class="text-ink-2 text-sm">{{ l.detail ?? '—' }}</TableCell>
             <TableCell>
               <Badge v-if="l.success" variant="secondary">OK</Badge>
               <Badge v-else variant="destructive">Error</Badge>
@@ -201,7 +201,7 @@ onMounted(fetchLogs)
     </div>
 
     <div v-if="totalPages() > 1" class="flex items-center justify-between">
-      <p class="text-sm text-muted-foreground">
+      <p class="text-sm text-ink-2">
         Page {{ page }} of {{ totalPages() }}
       </p>
       <div class="flex gap-2">
@@ -211,3 +211,26 @@ onMounted(fetchLogs)
     </div>
   </div>
 </template>
+
+<style scoped>
+.admin-error {
+  border: 1px solid var(--c-again);
+  border-radius: 9px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--c-again);
+}
+.admin-select {
+  height: 36px;
+  border-radius: 9px;
+  border: 1px solid var(--rule-1);
+  background: var(--paper-1);
+  color: var(--ink-0);
+  padding: 0 12px;
+  font-size: 13px;
+}
+.admin-select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+}
+</style>

--- a/fasolt.client/src/views/admin/AdminOverviewView.vue
+++ b/fasolt.client/src/views/admin/AdminOverviewView.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { apiFetch } from '@/api/client'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 
 interface AdminStats {
   totalUsers: number
@@ -56,12 +54,12 @@ const groups = computed(() => {
     {
       title: 'Activity',
       cards: [
-        { label: 'Sign-ups · 7 days', value: s.registrationsLast7d, sub: `${s.registrationsLast30d} in 30 days` },
+        { label: 'Sign-ups · 7 days', value: s.registrationsLast7d, sub: `${s.registrationsLast30d} in 30 days`, tone: 'accent' },
       ],
     },
   ] as Array<{
     title: string
-    cards: Array<{ label: string; value: number; sub?: string; tone?: 'warn' }>
+    cards: Array<{ label: string; value: number; sub?: string; tone?: 'warn' | 'accent' }>
   }>
 })
 
@@ -71,41 +69,97 @@ function fmt(n: number) {
 </script>
 
 <template>
-  <div class="space-y-6">
-    <div class="flex items-center justify-between">
+  <div class="overview">
+    <header class="ov-head">
       <div>
-        <h2 class="text-lg font-semibold tracking-tight">Overview</h2>
-        <p class="text-sm text-muted-foreground">A snapshot of users, content, and recent activity.</p>
+        <h2 class="ov-title">Overview</h2>
+        <p class="ov-sub">A snapshot of users, content, and recent activity.</p>
       </div>
-      <Button variant="outline" size="sm" :disabled="isLoading" @click="fetchStats">Refresh</Button>
-    </div>
+      <button class="fa-btn" :disabled="isLoading" @click="fetchStats">Refresh</button>
+    </header>
 
-    <div v-if="errorMessage" class="rounded-md border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive">
-      {{ errorMessage }}
-    </div>
+    <div v-if="errorMessage" class="ov-error">{{ errorMessage }}</div>
 
-    <div v-if="isLoading && !stats" class="text-sm text-muted-foreground">Loading…</div>
+    <div v-if="isLoading && !stats" class="ov-loading">Loading…</div>
 
-    <div v-for="group in groups" :key="group.title" class="space-y-2">
-      <h3 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{{ group.title }}</h3>
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        <Card v-for="c in group.cards" :key="c.label">
-          <CardHeader class="pb-2">
-            <CardTitle class="text-xs font-medium text-muted-foreground">{{ c.label }}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div
-              :class="[
-                'text-3xl font-semibold tabular-nums',
-                c.tone === 'warn' ? 'text-destructive' : 'text-foreground',
-              ]"
-            >
-              {{ fmt(c.value) }}
-            </div>
-            <div v-if="c.sub" class="mt-1 text-xs text-muted-foreground">{{ c.sub }}</div>
-          </CardContent>
-        </Card>
+    <div v-for="group in groups" :key="group.title" class="ov-group">
+      <h3 class="fa-cap">{{ group.title }}</h3>
+      <div class="ov-stats" :class="`ov-stats-${Math.min(group.cards.length, 3)}`">
+        <div v-for="c in group.cards" :key="c.label" class="ov-stat">
+          <div class="ov-stat-label">{{ c.label }}</div>
+          <div
+            class="ov-stat-value fa-num"
+            :class="{ 'is-warn': c.tone === 'warn', 'is-accent': c.tone === 'accent' }"
+          >
+            {{ fmt(c.value) }}
+          </div>
+          <div v-if="c.sub" class="ov-stat-sub">{{ c.sub }}</div>
+        </div>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.overview { display: flex; flex-direction: column; gap: 28px; }
+
+.ov-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.ov-title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink-0);
+  margin: 0;
+}
+.ov-sub { margin: 4px 0 0; font-size: 13px; color: var(--ink-2); }
+
+.ov-error {
+  border: 1px solid var(--c-again);
+  background: transparent;
+  border-radius: 9px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--c-again);
+}
+.ov-loading { font-size: 13px; color: var(--ink-2); }
+
+.ov-group { display: flex; flex-direction: column; gap: 10px; }
+
+.ov-stats {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1px;
+  background: var(--rule-1);
+  border: 1px solid var(--rule-1);
+  border-radius: 12px;
+  overflow: hidden;
+}
+@media (min-width: 640px) {
+  .ov-stats-2 { grid-template-columns: 1fr 1fr; }
+  .ov-stats-3 { grid-template-columns: 1fr 1fr; }
+}
+@media (min-width: 1024px) {
+  .ov-stats-3 { grid-template-columns: 1fr 1fr 1fr; }
+}
+
+.ov-stat {
+  background: var(--paper-1);
+  padding: 16px 18px;
+}
+.ov-stat-label { font-size: 12.5px; color: var(--ink-2); }
+.ov-stat-value {
+  margin-top: 6px;
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--ink-0);
+}
+.ov-stat-value.is-warn { color: var(--c-again); }
+.ov-stat-value.is-accent { color: var(--accent-text); }
+.ov-stat-sub { margin-top: 4px; font-size: 12px; color: var(--ink-2); }
+</style>

--- a/fasolt.client/src/views/admin/AdminUsersView.vue
+++ b/fasolt.client/src/views/admin/AdminUsersView.vue
@@ -187,19 +187,19 @@ onMounted(fetchUsers)
   <div class="space-y-4">
     <div class="flex items-center justify-between">
       <div>
-        <h2 class="text-lg font-semibold tracking-tight">Users</h2>
-        <p class="text-sm text-muted-foreground">{{ totalCount }} total</p>
+        <h2 class="text-lg font-semibold tracking-tight text-ink-0">Users</h2>
+        <p class="text-sm text-ink-2">{{ totalCount }} total</p>
       </div>
     </div>
 
-    <div v-if="errorMessage" class="rounded-md border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive">
+    <div v-if="errorMessage" class="admin-error">
       {{ errorMessage }}
       <button class="ml-2 underline" @click="errorMessage = null">Dismiss</button>
     </div>
 
     <div class="flex flex-wrap items-end gap-3">
-      <div class="flex flex-col gap-1 flex-1 min-w-[200px]">
-        <label class="text-xs font-medium text-muted-foreground" for="user-search">Search</label>
+      <div class="flex flex-col gap-1.5 flex-1 min-w-[200px]">
+        <label class="fa-cap" for="user-search">Search</label>
         <Input
           id="user-search"
           v-model="search"
@@ -207,12 +207,12 @@ onMounted(fetchUsers)
           placeholder="Email or username..."
         />
       </div>
-      <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium text-muted-foreground" for="user-provider">Provider</label>
+      <div class="flex flex-col gap-1.5">
+        <label class="fa-cap" for="user-provider">Provider</label>
         <select
           id="user-provider"
           v-model="providerFilter"
-          class="h-10 rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          class="admin-select"
         >
           <option value="">All</option>
           <option value="Email">Email</option>
@@ -220,18 +220,18 @@ onMounted(fetchUsers)
           <option value="Apple">Apple</option>
         </select>
       </div>
-      <label class="flex h-10 items-center gap-2 text-sm">
-        <input v-model="lockedOnly" type="checkbox" class="h-4 w-4 rounded border-input" />
+      <label class="flex h-9 items-center gap-2 text-sm text-ink-1">
+        <input v-model="lockedOnly" type="checkbox" class="h-4 w-4 rounded accent-[var(--accent)] border-input" />
         Locked only
       </label>
-      <label class="flex h-10 items-center gap-2 text-sm">
-        <input v-model="hasPushOnly" type="checkbox" class="h-4 w-4 rounded border-input" />
+      <label class="flex h-9 items-center gap-2 text-sm text-ink-1">
+        <input v-model="hasPushOnly" type="checkbox" class="h-4 w-4 rounded accent-[var(--accent)] border-input" />
         Push enabled
       </label>
       <Button v-if="hasActiveFilters()" variant="ghost" size="sm" @click="clearFilters">Clear</Button>
     </div>
 
-    <div class="rounded-md border">
+    <div class="fa-surface overflow-hidden">
       <Table>
         <TableHeader>
           <TableRow>
@@ -247,13 +247,13 @@ onMounted(fetchUsers)
         </TableHeader>
         <TableBody>
           <TableRow v-if="isLoading">
-            <TableCell :colspan="8" class="text-center text-muted-foreground">Loading…</TableCell>
+            <TableCell :colspan="8" class="text-center text-ink-2">Loading…</TableCell>
           </TableRow>
           <TableRow v-else-if="users.length === 0">
-            <TableCell :colspan="8" class="text-center text-muted-foreground">No users match the current filters.</TableCell>
+            <TableCell :colspan="8" class="text-center text-ink-2">No users match the current filters.</TableCell>
           </TableRow>
           <TableRow v-for="u in users" :key="u.id">
-            <TableCell class="font-medium">
+            <TableCell class="font-medium text-ink-0">
               <span class="inline-flex items-center gap-2">
                 {{ u.displayName || u.email }}
                 <span
@@ -264,7 +264,7 @@ onMounted(fetchUsers)
                 >&#x2713;</span>
                 <span
                   v-else
-                  class="text-muted-foreground"
+                  class="text-ink-3"
                   title="Email not confirmed"
                   aria-label="Email not confirmed"
                 >&#x25CB;</span>
@@ -272,20 +272,20 @@ onMounted(fetchUsers)
             </TableCell>
             <TableCell>
               <Badge v-if="u.externalProvider" variant="secondary">{{ u.externalProvider }}</Badge>
-              <span v-else class="text-xs text-muted-foreground">Email</span>
+              <span v-else class="text-xs text-ink-2">Email</span>
             </TableCell>
-            <TableCell class="text-right tabular-nums">{{ u.cardCount }}</TableCell>
-            <TableCell class="text-right tabular-nums">{{ u.deckCount }}</TableCell>
+            <TableCell class="text-right tabular-nums text-ink-1">{{ u.cardCount }}</TableCell>
+            <TableCell class="text-right tabular-nums text-ink-1">{{ u.deckCount }}</TableCell>
             <TableCell>
               <Badge v-if="u.hasPush" variant="secondary">Yes</Badge>
-              <span v-else class="text-muted-foreground">—</span>
+              <span v-else class="text-ink-3">—</span>
             </TableCell>
             <TableCell>
               <Badge v-if="u.isLockedOut" variant="destructive">Locked</Badge>
               <Badge v-else variant="secondary">Active</Badge>
             </TableCell>
             <TableCell
-              class="whitespace-nowrap text-sm text-muted-foreground"
+              class="whitespace-nowrap text-sm text-ink-2"
               :title="u.lastActivityAt ? new Date(u.lastActivityAt).toLocaleString() : ''"
             >
               {{ formatLastActivity(u.lastActivityAt) }}
@@ -304,7 +304,7 @@ onMounted(fetchUsers)
     </div>
 
     <div v-if="totalPages() > 1" class="flex items-center justify-between">
-      <p class="text-sm text-muted-foreground">
+      <p class="text-sm text-ink-2">
         Page {{ page }} of {{ totalPages() }}
       </p>
       <div class="flex gap-2">
@@ -344,3 +344,26 @@ onMounted(fetchUsers)
     </Dialog>
   </div>
 </template>
+
+<style scoped>
+.admin-error {
+  border: 1px solid var(--c-again);
+  border-radius: 9px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--c-again);
+}
+.admin-select {
+  height: 36px;
+  border-radius: 9px;
+  border: 1px solid var(--rule-1);
+  background: var(--paper-1);
+  color: var(--ink-0);
+  padding: 0 12px;
+  font-size: 13px;
+}
+.admin-select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+}
+</style>

--- a/fasolt.client/tailwind.config.js
+++ b/fasolt.client/tailwind.config.js
@@ -80,9 +80,10 @@ module.exports = {
         },
       },
       fontFamily: {
-        sans: ['Geist', 'system-ui', 'sans-serif'],
-        mono: ['Geist Mono', 'ui-monospace', 'JetBrains Mono', 'monospace'],
-        serif: ['Instrument Serif', 'Times New Roman', 'serif'],
+        // UI uses the platform system font. 'Geist' is reserved for the wordmark only.
+        sans: ['-apple-system', 'BlinkMacSystemFont', 'system-ui', 'Segoe UI', 'Roboto', 'sans-serif'],
+        mono: ['ui-monospace', 'SF Mono', 'Menlo', 'monospace'],
+        brand: ['Geist', 'system-ui', 'sans-serif'],
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary

Reworks the webapp's look away from the generic "AI-made" aesthetic (Geist font + warm-neutral paper + one tasteful accent + uppercase-mono micro-labels + hairline grids — the Vercel/Linear "default good taste") toward a calmer, more distinctive language **anchored on Things** (chosen by the user for being "simple and functional").

The escape from "AI slop" is subtractive — everything that makes Things not-look-AI is restraint:

- **System font for all UI** (SF on Apple). The fasolt **wordmark keeps its Geist logotype**; the rest of the app drops Geist / Geist Mono / Instrument Serif. Also removes the designer-webfont load.
- **One warm marigold accent** (`#EE9B42`), replacing vermilion — used only where it means something (primary action, active state, "today/due", progress). Truer to fasolt, which already ran on a warm accent.
- **Whitespace over borders/cards**; calmed sentence-case labels; gentle radii.
- **No gloss** — removed gradients, glow/pulse, inset-highlight shadows, frosted-glass navs, hover-lift.
- **Full light + dark** token palettes (white / warm-charcoal).

### Notable UX changes
- **Study** rebuilt to the approved mockup: a **meaningful "Today" star** (filled/amber once you've reviewed today → streak safe; hollow/muted until then), calm hero number, **deck progress rings**, inline streak, quiet stats line instead of bordered stat-tiles. Dropped the redundant "All decks" link.
- **Breadcrumb trails** (`Decks / Deck / Card`) replaced with a single quiet **back link**.
- Landing study-preview now shows the **deck being reviewed**, not a streak star.

## How it was built
1. Frozen **foundation**: tokens, system type, de-glossed shared `.fa-*` classes (`style.css`, `tailwind.config.js`, `index.html`).
2. **StudyView** rebuilt by hand to match the approved direction.
3. A parallel agent sweep applied the language to ~33 remaining views/components, each independently verified against a checklist; real findings folded back in (tool-switcher dark-mode, frosted navs, overlay shadow tokens).

Design spec: `docs/superpowers/specs/2026-06-13-things-design-language.md`

## Test plan
- [x] `npm run build` (vue-tsc + vite) passes
- [x] Browser spot-check in **light and dark**: Study, Review (incl. status-colored rating buttons), Landing
- [ ] Reviewer: skim the remaining secondary screens (Cards, Decks, Settings, MCP, admin) in both themes

## Follow-up
- iOS derivation reuses these tokens/patterns (separate effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)