### PR TITLE
web(landing): drop redundant 'Spaced repetition' eyebrow

### DIFF
--- a/fasolt.client/src/views/LandingView.vue
+++ b/fasolt.client/src/views/LandingView.vue
@@ -28,7 +28,6 @@ import { ArrowRight, ArrowDown } from 'lucide-vue-next'
     <!-- Hero -->
     <section class="relative mx-auto max-w-5xl px-6 pt-6 pb-12 sm:pt-10 sm:pb-16">
       <div class="max-w-2xl">
-        <p class="fa-cap mb-4 text-accent-text">Spaced repetition</p>
         <h1 class="page-title text-3xl sm:text-5xl mb-5">
           Spaced repetition,<br class="hidden sm:block" />
           powered by the <span class="text-accent-text">AI you already use</span>.


### PR DESCRIPTION
The hero had a small "Spaced repetition" eyebrow label directly above the `<h1>`, which itself begins "Spaced repetition, powered by the AI you already use." — the same words twice. Drop the eyebrow so the hero opens on the headline.

One-line removal; spacing handled by the section's existing top padding.

## Test plan
- [x] `npm run build` passes
- [x] Hero verified in browser — headline is now the first element, layout intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)